### PR TITLE
Pin PHP version to the last known working.

### DIFF
--- a/bay/images/Dockerfile.php
+++ b/bay/images/Dockerfile.php
@@ -1,4 +1,4 @@
-FROM amazeeio/php:7.1-fpm
+FROM amazeeio/php:7.1-fpm-v0.24.0
 
 # Add ClamAV.
 RUN apk add --update clamav clamav-libunrar \


### PR DESCRIPTION
Latest Lagoon build pulled in an updated PHP image that is causing issues for Bay - this will pin PHP to the last known working version of the PHP container.