### PR TITLE
Revert "Pin PHP version to the last known working."

### DIFF
--- a/bay/images/Dockerfile.php
+++ b/bay/images/Dockerfile.php
@@ -1,4 +1,4 @@
-FROM amazeeio/php:7.1-fpm-v0.24.0
+FROM amazeeio/php:7.1-fpm
 
 # Add ClamAV.
 RUN apk add --update clamav clamav-libunrar \


### PR DESCRIPTION
Reverts dpc-sdp/bay#27

The fix for Redis has been applied in the upstream Lagoon image.