### PR TITLE
Redis failover.

### DIFF
--- a/bay/images/Dockerfile.builder
+++ b/bay/images/Dockerfile.builder
@@ -22,4 +22,5 @@ RUN apk update \
 # Add common drupal config.
 RUN mkdir /bay
 COPY docker/services.yml /bay
+COPY docker/redis-unavailable.services.yml /bay
 COPY docker/settings.php /bay

--- a/bay/images/Dockerfile.php
+++ b/bay/images/Dockerfile.php
@@ -19,6 +19,7 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
 # Add common drupal config.
 RUN mkdir /bay
 COPY docker/services.yml /bay
+COPY docker/redis-unavailable.services.yml /bay
 COPY docker/settings.php /bay
 
 ENV TZ=Australia/Melbourne

--- a/bay/images/docker/redis-unavailable.services.yml
+++ b/bay/images/docker/redis-unavailable.services.yml
@@ -3,6 +3,6 @@
 # Add the cache backend null service to be used if redis is unavailable.
 #
 
- services:
+services:
   cache.backend.null:
     class: Drupal\Core\Cache\NullBackendFactory

--- a/bay/images/docker/redis-unavailable.services.yml
+++ b/bay/images/docker/redis-unavailable.services.yml
@@ -2,7 +2,6 @@
 #
 # Add the cache backend null service to be used if redis is unavailable.
 #
-
 services:
   cache.backend.null:
     class: Drupal\Core\Cache\NullBackendFactory

--- a/bay/images/docker/redis-unavailable.services.yml
+++ b/bay/images/docker/redis-unavailable.services.yml
@@ -1,0 +1,8 @@
+### Lagoon Drupal 8 redis unavailable services.
+#
+# Add the cache backend null service to be used if redis is unavailable.
+#
+
+ services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory

--- a/bay/images/docker/settings.php
+++ b/bay/images/docker/settings.php
@@ -47,18 +47,37 @@ $config['environment_indicator.indicator']['bg_color'] = !empty($config['environ
 // Disable local split.
 $config['config_split.config_split.local']['status'] = FALSE;
 
-// Redis.
-if (!drupal_installation_attempted()) {
-  $settings['redis.connection']['host'] = 'redis';
-  $settings['redis.connection']['port'] = '6379';
-  $settings['redis.connection']['password'] = '';
-  $settings['redis.connection']['base'] = 0;
-  $settings['redis.connection']['interface'] = 'PhpRedis';
-  $settings['cache']['default'] = 'cache.backend.redis';
-  $settings['cache']['bins']['bootstrap'] = 'cache.backend.chainedfast';
-  $settings['cache']['bins']['discovery'] = 'cache.backend.chainedfast';
-  $settings['cache']['bins']['config'] = 'cache.backend.chainedfast';
-  $settings['container_yamls'][] = $contrib_path . '/redis/example.services.yml';
+if (getenv('ENABLE_REDIS')) {
+  $redis_host = getenv('REDIS_HOST') ?: 'redis';
+  $redis_port = getenv('REDIS_PORT') ?: '6379';
+  try {
+    if (drupal_installation_attempted()) {
+      throw new \Exception('Drupal installation underway.');
+    }
+    $redis = new \Redis();
+    $redis->connect($redis_host, $redis_port);
+    $response = $redis->ping();
+    if (strpos($response, 'PONG') === 'FALSE') {
+      throw new \Exception('Redis reachable but is not responding correctly.');
+    }
+    $settings['redis.connection']['host'] = $redis_host;
+    $settings['redis.connection']['port'] = $redis_port;
+    $settings['redis.connection']['password'] = '';
+    $settings['redis.connection']['base'] = 0;
+    $settings['redis.connection']['interface'] = 'PhpRedis';
+    $settings['cache']['default'] = 'cache.backend.redis';
+    $settings['cache']['bins']['bootstrap'] = 'cache.backend.chainedfast';
+    $settings['cache']['bins']['discovery'] = 'cache.backend.chainedfast';
+    $settings['cache']['bins']['config'] = 'cache.backend.chainedfast';
+    $settings['container_yamls'][] = $contrib_path . '/redis/example.services.yml';
+  } catch (\Exception $error) {
+    // Make the reqeust unacacheable until redis is available.
+    // This will ensure that cache partials are not added to separate bins,
+    // Drupal is available even when Redis is down and that when redis is
+    // available again we can start filling the correct bins up again.
+    $settings['container_yamls'][] = '/bay/redis-unavailable.services.yml';
+    $settings['cache']['default'] = 'cache.backend.null';
+  }
 }
 
 // Expiration of cached pages on Varnish to 15 min

--- a/bay/images/docker/settings.php
+++ b/bay/images/docker/settings.php
@@ -49,7 +49,8 @@ $config['config_split.config_split.local']['status'] = FALSE;
 
 if (getenv('ENABLE_REDIS')) {
   $redis_host = getenv('REDIS_HOST') ?: 'redis';
-  $redis_port = getenv('REDIS_PORT') ?: '6379';
+  // Kube service discovery sets REDIS_PORT to a TCP address.
+  $redis_port = getenv('REDIS_SERVICE_PORT') ?: '6379';
   try {
     if (drupal_installation_attempted()) {
       throw new \Exception('Drupal installation underway.');


### PR DESCRIPTION
Updates the Drupal redis configuration so that it can fallback to a null cache backend if the redis service is unavailable.

- Copies cache backend service definition to both CLI + PHP container
- Updates settings.php to ping redis
- Falls back to cache backend null.