### PR TITLE
Fixed accessing non-existing config value.

### DIFF
--- a/bay/images/docker/settings.php
+++ b/bay/images/docker/settings.php
@@ -41,7 +41,7 @@ $settings['file_scan_ignore_directories'] = [
 $settings['entity_update_batch_size'] = 50;
 
 // Environment indicator settings.
-$config['environment_indicator.indicator']['name'] = $config['environment'];
+$config['environment_indicator.indicator']['name'] = isset($settings['environment']) ? $settings['environment'] : 'local';
 $config['environment_indicator.indicator']['bg_color'] = !empty($config['environment_indicator.indicator']['bg_color']) ? $config['environment_indicator.indicator']['bg_color'] : 'green';
 
 // Disable local split.


### PR DESCRIPTION
Fixed environment indicator text being retrieved from $config['environment'] rather than $settings['environment'].

Tide-based websites are setting environment information using $settings['environment'].

(Originally created by @AlexSkrypnyk on March 18 2019)