### PR TITLE
[DDIDO-349]: Update ci-builder to python3.

### DIFF
--- a/bay/images/Dockerfile.ci-builder
+++ b/bay/images/Dockerfile.ci-builder
@@ -4,9 +4,21 @@ FROM integratedexperts/ci-builder:latest
 # Install SDP ci dependencies.
 COPY --from=terraform /bin/terraform /bin/terraform
 RUN apt-get update && \
-    apt-get install ansible python python3-distutils ansible-lint python-pip rsync jq hub -y && \
+    apt-get install python3 python3-distutils python3-pip rsync jq hub -y && \
     apt-get clean -y
-RUN pip install flake8 awscli yamllint
+
+# Support the python shebang.
+# @DEPRECATED
+RUN ln -s /usr/bin/python3 /usr/bin/python && ln -s /usr/bin/pip3 /usr/bin/pip
+
+# Manage python deps via pip rather than apt.
+# ansible via apt is 2.7.7 rather than 2.8+
+RUN pip install ansible ansible-lint flake8 awscli yamllint
+
+# yamllint install pyyaml@3.13 - we have been using 5+ this is backwards
+# compatible for yamllint and ansible and means our inventory scripts will
+# work as expected.
+RUN pip install -U pyyaml==5.3.1 --force-reinstall
 
 # Install Lagoon CLI.
 RUN curl -L "https://github.com/amazeeio/lagoon-cli/releases/download/0.9.2/lagoon-cli-0.9.2-linux-amd64" -o /usr/local/bin/lagoon && \


### PR DESCRIPTION
**JIRA issue**: https://digital-engagement.atlassian.net/browse/DDIDO-349

### Changed
- Installs python3
- Creates a symlink from python3 to python to preserve shebangs and backwards compatibility (mostly) for our internal apps
- Updates pyyaml to 5.3.1 to support new load methods which the inventory python scripts rely on
- Install ansible via pip rather than apt - the apt mirror for ansible is outdated and doesn't get updated frequently (apt is at 2.7 pip will install 2.8) - this is required as we use `meta: end_host` in the plays to control execution flow
