### PR TITLE
[DDIDO-201]: Add support for ingress protection to nginx.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ Lagoon solves what developers are dreaming about: A system that allows developer
 # Use
 Learn more from https://lagoon.readthedocs.io/en/latest/
 
+# Bay Features
+
+## Lock-down Ingress with Pre-Shared Key
+
+Using the nginx image, you can lock down access to your application with using a pre-shared key added at your CDN. 
+
+Set these environment variables in your nginx deployment:
+
+- `BAY_INGRESS_HEADER` defines the header which has the pre-shared key.
+- `BAY_INGRESS_PSK` is the token / PSK value.
+- `BAY_INGRESS_ENABLED` is a toggle for this feature, must be set to `"true"`.
+
+In your CDN configuration, set the header defined in `BAY_INGRESS_HEADER` with the token defined in `BAY_INGRESS_PSK`.
+
+- [Cloudfront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html)
+
+Once deployed, if the header is missing in the request nginx will return a `405 Not Allowed` HTTP response.
+
 # Contribute
 [Open an issue](https://github.com/dpc-sdp/bay) on GitHub or submit a pull request with suggested changes.
 

--- a/bay/images/Dockerfile.nginx
+++ b/bay/images/Dockerfile.nginx
@@ -3,7 +3,13 @@ FROM amazeeio/nginx-drupal
 ENV WEBROOT=docroot
 ENV TZ=Australia/Melbourne
 
+# Add ingress protection environment variable supprot to nginx.
+RUN sed -i '/env\ LAGOON_ENVIRONMENT_TYPE\;/a env BAY_INGRESS_ENABLED\;' /etc/nginx/nginx.conf \
+    && sed -i '/env\ LAGOON_ENVIRONMENT_TYPE\;/a env BAY_INGRESS_HEADER\;' /etc/nginx/nginx.conf \
+    && sed -i '/env\ LAGOON_ENVIRONMENT_TYPE\;/a env BAY_INGRESS_PSK\;' /etc/nginx/nginx.conf
+
 COPY nginx/helpers/ /etc/nginx/helpers/
+COPY nginx/prepend/ /etc/nginx/conf.d/drupal/
 
 RUN fix-permissions /etc/nginx \
     && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \

--- a/bay/images/nginx/prepend/location_prepend_ingress_control.conf
+++ b/bay/images/nginx/prepend/location_prepend_ingress_control.conf
@@ -12,8 +12,7 @@ access_by_lua_block {
     return
   end
 
-  local ingress_protection_header_key = 'x-sdp-ingress-protection-' .. ingress_protection_key
-  local sent_psk = ngx.req.get_headers()[ingress_protection_header_key]
+  local sent_psk = ngx.req.get_headers()[ingress_protection_key]
 
   if (ingress_protection_enabled == "true") and (ingress_protection_psk ~= sent_psk) then
     ngx.exit(ngx.HTTP_NOT_ALLOWED)

--- a/bay/images/nginx/prepend/location_prepend_ingress_control.conf
+++ b/bay/images/nginx/prepend/location_prepend_ingress_control.conf
@@ -1,0 +1,15 @@
+# Bay Ingress Protection
+#
+# Allows nginx to reject requests if the corresponding PSK is not given by
+# the requesting client.
+
+access_by_lua_block {
+  local ingress_protection_enabled = os.getenv('BAY_INGRESS_ENABLED')
+  local ingress_protection_psk = os.getenv('BAY_INGRESS_PSK')
+  local ingress_protection_header_key = 'x-sdp-ingress-protection-' .. os.getenv('BAY_INGRESS_HEADER')
+  local sent_psk = ngx.req.get_headers()[ingress_protection_header_key]
+
+  if (ingress_protection_enabled == "true") and (ingress_protection_psk ~= sent_psk) then
+    ngx.exit(ngx.HTTP_NOT_ALLOWED)
+  end
+}

--- a/bay/images/nginx/prepend/location_prepend_ingress_control.conf
+++ b/bay/images/nginx/prepend/location_prepend_ingress_control.conf
@@ -6,7 +6,13 @@
 access_by_lua_block {
   local ingress_protection_enabled = os.getenv('BAY_INGRESS_ENABLED')
   local ingress_protection_psk = os.getenv('BAY_INGRESS_PSK')
-  local ingress_protection_header_key = 'x-sdp-ingress-protection-' .. os.getenv('BAY_INGRESS_HEADER')
+  local ingress_protection_key = os.getenv('BAY_INGRESS_HEADER')
+
+  if (ingress_protection_enabled == nil) or (ingress_protection_psk == nil) or (ingress_protection_key == nil) then
+    return
+  end
+
+  local ingress_protection_header_key = 'x-sdp-ingress-protection-' .. ingress_protection_key
   local sent_psk = ngx.req.get_headers()[ingress_protection_header_key]
 
   if (ingress_protection_enabled == "true") and (ingress_protection_psk ~= sent_psk) then


### PR DESCRIPTION
**Issue:** https://digital-engagement.atlassian.net/browse/DDIDO-201

### Changes

- Adds env var support to nginx.conf so lua can access them at runtime.
- Adds location prepend support
- Adds a lua script to enable ingress protection

### Screenshots

```
$ http -h http://content-vic.docker.amazee.io x-sdp-ingress-protection-asfd:12345
HTTP/1.1 302 Found

$ http -h http://content-vic.docker.amazee.io x-sdp-ingress-protection-asfd:1234545655
HTTP/1.1 405 Not Allowed

$ http -h http://content-vic.docker.amazee.io
HTTP/1.1 405 Not Allowed

$ http -h http://content-vic.docker.amazee.io x-sdp-ingress-protection-dfsa:12345
HTTP/1.1 405 Not Allowed
```