### PR TITLE
Add boto3 to the ci builder image.

### DIFF
--- a/bay/images/Dockerfile.ci-builder
+++ b/bay/images/Dockerfile.ci-builder
@@ -13,7 +13,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python && ln -s /usr/bin/pip3 /usr/bin/pip
 
 # Manage python deps via pip rather than apt.
 # ansible via apt is 2.7.7 rather than 2.8+
-RUN pip install ansible ansible-lint flake8 awscli yamllint
+RUN pip install ansible ansible-lint flake8 awscli yamllint boto3
 
 # yamllint install pyyaml@3.13 - we have been using 5+ this is backwards
 # compatible for yamllint and ansible and means our inventory scripts will


### PR DESCRIPTION
- Adds boto3 python library to the CI image

The AWS KMS role provides a filter that relies on boto3. Rather than having all implementing pipelines install this directly. We should bundle this with the base ci builder image to make sure it runs correctly.

Fixes the following error in CI:

```
[WARNING]: Skipping plugin (/app/roles/sdp_aws/filter_plugins/aws_filters.py) as it seems to be invalid: No module named 'boto3'
```

