### PR TITLE
[SDPA-4484] Added phpinfo to disable_functions in php.ini.

### DIFF
--- a/bay/images/Dockerfile.php
+++ b/bay/images/Dockerfile.php
@@ -1,5 +1,8 @@
 FROM amazeeio/php:7.2-fpm
 
+# Disable calling phpinfo().
+RUN sed -i 's/disable_functions =/disable_functions = phpinfo,/' /usr/local/etc/php/php.ini
+
 # Add blackfire probe.
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mkdir -p /blackfire \

--- a/bay/images/Dockerfile.php
+++ b/bay/images/Dockerfile.php
@@ -1,7 +1,7 @@
 FROM amazeeio/php:7.2-fpm
 
 # Disable calling phpinfo().
-RUN sed -i 's/disable_functions =/disable_functions = phpinfo,/' /usr/local/etc/php/php.ini
+COPY php/php.ini /usr/local/etc/php/conf.d/01-bay-php.ini
 
 # Add blackfire probe.
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \

--- a/bay/images/php/php.ini
+++ b/bay/images/php/php.ini
@@ -1,0 +1,4 @@
+[PHP]
+
+; Disable calling phpinfo() - prepended to list provided by amazeeio/php image.
+disable_functions = phpinfo,pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,

--- a/tests/goss.php.yaml
+++ b/tests/goss.php.yaml
@@ -3,3 +3,8 @@ command:
     exit-status: 0
     stdout:
       - 7.2.32
+  # Ensure phpinfo() disabled by disable_functions config.
+  php -r "phpinfo();":
+    exit-status: 0
+    stderr:
+      - "PHP Warning:  phpinfo() has been disabled for security reasons in Command line code on line 1"


### PR DESCRIPTION
Adds `phpinfo()` to the list of disabled functions in php.ini. This prevents sensitive environment variables being exposed at `/admin/reports/status/php`