### PR TITLE
Disables Lagoon CLI directory branch check.

### DIFF
--- a/bay/images/Dockerfile.ci-builder
+++ b/bay/images/Dockerfile.ci-builder
@@ -23,3 +23,4 @@ RUN pip install -U pyyaml==5.3.1 --force-reinstall
 # Install Lagoon CLI.
 RUN curl -L "https://github.com/amazeeio/lagoon-cli/releases/download/0.9.2/lagoon-cli-0.9.2-linux-amd64" -o /usr/local/bin/lagoon && \
     chmod +x /usr/local/bin/lagoon
+RUN lagoon config feature --disable-project-directory-check true


### PR DESCRIPTION
There are some ansible plays which change directory when running lagoon commands to avoid hitting this. Might save us a few WTFs in future