### PR TITLE
Add redis cluster support.

### DIFF
--- a/bay/images/Dockerfile.builder
+++ b/bay/images/Dockerfile.builder
@@ -27,4 +27,6 @@ RUN curl -L https://github.com/itchyny/gojq/releases/download/v0.11.2/gojq_v0.11
 RUN mkdir /bay
 COPY docker/services.yml /bay
 COPY docker/redis-unavailable.services.yml /bay
+COPY docker/redis-cluster.services.yml /bay
+COPY docker/redis-single.services.yml /bay
 COPY docker/settings.php /bay

--- a/bay/images/docker/redis-cluster.services.yml
+++ b/bay/images/docker/redis-cluster.services.yml
@@ -1,0 +1,24 @@
+services:
+  # Cache tag checksum backend. Used by redis and most other cache backend
+  # to deal with cache tag invalidations.
+  cache_tags.invalidator.checksum:
+   class: Drupal\redis\Cache\PhpRedisClusterCacheTagsChecksum
+   arguments: ['@redis.factory']
+   tags:
+     - { name: cache_tags_invalidator }
+
+  # Replaces the default lock backend with a redis implementation.
+  lock:
+    class: Drupal\Core\Lock\LockBackendInterface
+    factory: ['@redis.lock.factory', get]
+
+  # Replaces the default persistent lock backend with a redis implementation.
+  lock.persistent:
+    class: Drupal\Core\Lock\LockBackendInterface
+    factory: ['@redis.lock.factory', get]
+    arguments: [true]
+
+  # Replaces the default flood backend with a redis implementation.
+  flood:
+    class: Drupal\Core\Flood\FloodInterface
+    factory: ['@redis.flood.factory', get]

--- a/bay/images/docker/redis-single.services.yml
+++ b/bay/images/docker/redis-single.services.yml
@@ -1,0 +1,24 @@
+services:
+  # Cache tag checksum backend. Used by redis and most other cache backend
+  # to deal with cache tag invalidations.
+  cache_tags.invalidator.checksum:
+   class: Drupal\redis\Cache\RedisCacheTagsChecksum
+   arguments: ['@redis.factory']
+   tags:
+     - { name: cache_tags_invalidator }
+
+  # Replaces the default lock backend with a redis implementation.
+  lock:
+    class: Drupal\Core\Lock\LockBackendInterface
+    factory: ['@redis.lock.factory', get]
+
+  # Replaces the default persistent lock backend with a redis implementation.
+  lock.persistent:
+    class: Drupal\Core\Lock\LockBackendInterface
+    factory: ['@redis.lock.factory', get]
+    arguments: [true]
+
+  # Replaces the default flood backend with a redis implementation.
+  flood:
+    class: Drupal\Core\Flood\FloodInterface
+    factory: ['@redis.flood.factory', get]

--- a/bay/images/docker/settings.php
+++ b/bay/images/docker/settings.php
@@ -131,11 +131,14 @@ if (getenv('ENABLE_REDIS')) {
     $settings['cache']['bins']['bootstrap'] = 'cache.backend.chainedfast';
     $settings['cache']['bins']['discovery'] = 'cache.backend.chainedfast';
     $settings['cache']['bins']['config'] = 'cache.backend.chainedfast';
-    $settings['container_yamls'][] = $contrib_path . '/redis/example.services.yml';
+
     $settings['cache_prefix']['default'] = getenv('REDIS_CACHE_PREFIX') ?: getenv('LAGOON_PROJECT') . '_' . getenv('LAGOON_GIT_SAFE_BRANCH');
 
     if ($redis_interface == 'PhpRedisCluster') {
       $settings['redis.connection']['seeds'] = ["$redis_host:$redis_port"];
+      $settings['container_yamls'][] = '/bay/redis-cluster.services.yml';
+    } else {
+      $settings['container_yamls'][] = '/bay/redis-single.services.yml';
     }
 
   } catch (\Exception $error) {

--- a/bay/images/docker/settings.php
+++ b/bay/images/docker/settings.php
@@ -91,6 +91,7 @@ if (getenv('ENABLE_REDIS')) {
     if (drupal_installation_attempted()) {
       throw new \Exception('Drupal installation underway.');
     }
+
     $redis = new \Redis();
 
     if ($redis->connect($redis_host, $redis_port, $redis_timeout) === FALSE) {
@@ -101,21 +102,42 @@ if (getenv('ENABLE_REDIS')) {
       $redis->auth($redis_password);
     }
 
-    $response = $redis->ping();
-    if (strpos($response, 'PONG') === 'FALSE') {
+    // Check the redis mode - to determine which interface we use to connect.
+    $info = $redis->info();
+    $redis_interface = 'PhpRedis';
+
+    if (isset($info['redis_mode']) && $info['redis_mode'] == 'cluster' && class_exists('\Drupal\redis\Cache\PhpRedisCluster')) {
+      $redis_interface = 'PhpRedisCluster';
+    }
+
+    if (getenv('REDIS_INTERFACE')) {
+      // Allow environment variable override for the interface (eg. forcing
+      // connection via a standalone pod).
+      $redis_interface = getenv('REDIS_INTERFACE');
+    }
+
+    if (strpos($redis->ping(), 'PONG') === 'FALSE') {
       throw new \Exception('Redis reachable but is not responding correctly.');
     }
+
     $settings['redis.connection']['host'] = $redis_host;
     $settings['redis.connection']['port'] = $redis_port;
-    $settings['redis.connection']['password'] = '';
+    $settings['redis.connection']['password'] = $redis_password;
     $settings['redis.connection']['base'] = 0;
-    $settings['redis.connection']['interface'] = 'PhpRedis';
+    $settings['redis.connection']['interface'] = $redis_interface;
+    $settings['redis.connection']['read_timeout'] = $redis_timeout;
+    $settings['redis.connection']['timeout'] = $redis_timeout;
     $settings['cache']['default'] = 'cache.backend.redis';
     $settings['cache']['bins']['bootstrap'] = 'cache.backend.chainedfast';
     $settings['cache']['bins']['discovery'] = 'cache.backend.chainedfast';
     $settings['cache']['bins']['config'] = 'cache.backend.chainedfast';
     $settings['container_yamls'][] = $contrib_path . '/redis/example.services.yml';
     $settings['cache_prefix']['default'] = getenv('REDIS_CACHE_PREFIX') ?: getenv('LAGOON_PROJECT') . '_' . getenv('LAGOON_GIT_SAFE_BRANCH');
+
+    if ($redis_interface == 'PhpRedisCluster') {
+      $settings['redis.connection']['seeds'] = ["$redis_host:$redis_port"];
+    }
+
   } catch (\Exception $error) {
     // Make the reqeust unacacheable until redis is available.
     // This will ensure that cache partials are not added to separate bins,


### PR DESCRIPTION
- Configures the Drupal/Redis module to use PhpRedisCluster if the class is available (requires Drupal patch)
- Adds `REDIS_INTERFACE` variable to override and hardcode an interface to use

Info is a fairly quick operation and shouldn't introduce too much latency between origin hits, but we might want to remove to save the look up and rely on a hard coded value. I _think_ the hit for the lookup is better than nocache or errors, but happy to shift implementation.

```
$ time redis-cli --cluster call redis-cluster:7000 info
real	0m0.014s
user	0m0.000s
sys	0m0.005s
```

Tested locally with a [redis-cluster set up](https://github.com/Grokzen/docker-redis-cluster), this image uses local redis instances listening on 700x and sets up 3 master/3 slave.

```
$ drush php
>>> \Drupal\Core\Site\Settings::get('redis.connection');
=> [
     "host" => "redis-cluster",
     "port" => "7000",
     "password" => false,
     "base" => 0,
     "interface" => "PhpRedisCluster",
     "read_timeout" => 2,
     "timeout" => 2,
     "seeds" => [
       "redis-cluster:7000",
     ],
   ]
```

```
$ redis-cli --cluster call redis-cluster:7000 info keyspace
>>> Calling info keyspace
redis-cluster:7000: # Keyspace
db0:keys=1496,expires=1496,avg_ttl=31535517961

192.168.16.4:7004: # Keyspace
db0:keys=1425,expires=1425,avg_ttl=0

192.168.16.4:7002: # Keyspace
db0:keys=1425,expires=1425,avg_ttl=31535517858

192.168.16.4:7005: # Keyspace
db0:keys=1496,expires=1496,avg_ttl=0

192.168.16.4:7003: # Keyspace
db0:keys=1524,expires=1524,avg_ttl=0

192.168.16.4:7001: # Keyspace
db0:keys=1524,expires=1524,avg_ttl=31535517778
```

