### PR TITLE
[DDS-767]: Install setuptools manually.

### DIFF
--- a/bay/images/Dockerfile.clamav
+++ b/bay/images/Dockerfile.clamav
@@ -6,8 +6,8 @@ RUN apk add --no-cache -u --repository http://dl-cdn.alpinelinux.org/alpine/edge
   clamav-daemon \
   clamav-libunrar \
   unrar \
-  supervisor \
-  nodejs
+  py3-setuptools \
+  supervisor
 
 # Add clamav user
 RUN mkdir -p /var/lib/clamav && \

--- a/tests/goss.clamav.yaml
+++ b/tests/goss.clamav.yaml
@@ -2,11 +2,11 @@ package:
   clamav-daemon:
     installed: true
     versions:
-    - 0.103.0-r1
+    - 0.103.2-r0
   clamav-libunrar:
     installed: true
     versions:
-    - 0.103.0-r1
+    - 0.103.2-r0
 process:
   clamd:
     running: true

--- a/tests/goss.php_goss.yaml
+++ b/tests/goss.php_goss.yaml
@@ -32,7 +32,7 @@ command:
   php -r "echo phpversion();":
     exit-status: 0
     stdout:
-      - "7\.4\.\d{1,2}"
+      - '/7\.4/'
 file:
   /usr/local/etc/php/conf.d/00-bay.ini:
     exists: true

--- a/tests/goss.php_goss.yaml
+++ b/tests/goss.php_goss.yaml
@@ -32,7 +32,7 @@ command:
   php -r "echo phpversion();":
     exit-status: 0
     stdout:
-      - 7.4.13
+      - "7\.4\.\d{1,2}"
 file:
   /usr/local/etc/php/conf.d/00-bay.ini:
     exists: true


### PR DESCRIPTION
- Fixes an issue with the clamav image build and `supervisor` no longer requiring its dependency