### PR TITLE
Updates gojq

### DIFF
--- a/bay/images/Dockerfile.builder
+++ b/bay/images/Dockerfile.builder
@@ -1,4 +1,5 @@
 FROM amazeeio/php:7.3-cli-drupal
+ARG GOJQ_VERSION=0.12.4
 
 ENV WEBROOT=docroot \
     COMPOSER_ALLOW_SUPERUSER=1 \
@@ -18,10 +19,10 @@ COPY php/mariadb-client.cnf /etc/my.cnf.d/
 RUN fix-permissions /etc/my.cnf.d/
 
 # Install gojq.
-RUN curl -L https://github.com/itchyny/gojq/releases/download/v0.11.2/gojq_v0.11.2_linux_amd64.tar.gz --output /tmp/gojq_v0.11.2_linux_amd64.tar.gz && \
-    tar -C /tmp -xvf /tmp/gojq_v0.11.2_linux_amd64.tar.gz && \
-    chmod +x /tmp/gojq_v0.11.2_linux_amd64/gojq && \
-    mv /tmp/gojq_v0.11.2_linux_amd64/gojq /usr/local/bin
+RUN curl -L https://github.com/itchyny/gojq/releases/download/v${GOJQ_VERSION}/gojq_v${GOJQ_VERSION}_linux_amd64.tar.gz --output /tmp/gojq_v${GOJQ_VERSION}_linux_amd64.tar.gz && \
+    tar -C /tmp -xvf /tmp/gojq_v${GOJQ_VERSION}_linux_amd64.tar.gz && \
+    chmod +x /tmp/gojq_v${GOJQ_VERSION}_linux_amd64/gojq && \
+    mv /tmp/gojq_v${GOJQ_VERSION}_linux_amd64/gojq /usr/local/bin
 
 # Add common drupal config.
 RUN mkdir /bay

--- a/bay/images/Dockerfile.ci-builder
+++ b/bay/images/Dockerfile.ci-builder
@@ -31,10 +31,10 @@ RUN curl -L "https://github.com/amazeeio/lagoon-cli/releases/download/0.10.0/lag
 RUN lagoon config feature --disable-project-directory-check true
 
 # Install gojq.
-RUN curl -L https://github.com/itchyny/gojq/releases/download/v0.11.2/gojq_v0.11.2_linux_amd64.tar.gz --output /tmp/gojq_v0.11.2_linux_amd64.tar.gz && \
-    tar -C /tmp -xvf /tmp/gojq_v0.11.2_linux_amd64.tar.gz && \
-    chmod +x /tmp/gojq_v0.11.2_linux_amd64/gojq && \
-    mv /tmp/gojq_v0.11.2_linux_amd64/gojq /usr/local/bin
+RUN curl -L https://github.com/itchyny/gojq/releases/download/v0.12.4/gojq_v0.12.4_linux_amd64.tar.gz --output /tmp/gojq_v0.12.4_linux_amd64.tar.gz && \
+    tar -C /tmp -xvf /tmp/gojq_v0.12.4_linux_amd64.tar.gz && \
+    chmod +x /tmp/gojq_v0.12.4_linux_amd64/gojq && \
+    mv /tmp/gojq_v0.12.4_linux_amd64/gojq /usr/local/bin
 
 # Install bats.
 RUN npm install -g bats@1.2.1

--- a/bay/images/Dockerfile.ci-builder
+++ b/bay/images/Dockerfile.ci-builder
@@ -1,5 +1,6 @@
 FROM hashicorp/terraform:light AS terraform
 FROM integratedexperts/ci-builder:latest
+ARG GOJQ_VERSION=0.12.4
 
 # Install SDP ci dependencies.
 COPY --from=terraform /bin/terraform /bin/terraform
@@ -31,10 +32,10 @@ RUN curl -L "https://github.com/amazeeio/lagoon-cli/releases/download/0.10.0/lag
 RUN lagoon config feature --disable-project-directory-check true
 
 # Install gojq.
-RUN curl -L https://github.com/itchyny/gojq/releases/download/v0.12.4/gojq_v0.12.4_linux_amd64.tar.gz --output /tmp/gojq_v0.12.4_linux_amd64.tar.gz && \
-    tar -C /tmp -xvf /tmp/gojq_v0.12.4_linux_amd64.tar.gz && \
-    chmod +x /tmp/gojq_v0.12.4_linux_amd64/gojq && \
-    mv /tmp/gojq_v0.12.4_linux_amd64/gojq /usr/local/bin
+RUN curl -L https://github.com/itchyny/gojq/releases/download/v${GOJQ_VERSION}/gojq_v${GOJQ_VERSION}_linux_amd64.tar.gz --output /tmp/gojq_v${GOJQ_VERSION}_linux_amd64.tar.gz && \
+    tar -C /tmp -xvf /tmp/gojq_v${GOJQ_VERSION}_linux_amd64.tar.gz && \
+    chmod +x /tmp/gojq_v${GOJQ_VERSION}_linux_amd64/gojq && \
+    mv /tmp/gojq_v${GOJQ_VERSION}_linux_amd64/gojq /usr/local/bin
 
 # Install bats.
 RUN npm install -g bats@1.2.1

--- a/bay/images/Dockerfile.circle
+++ b/bay/images/Dockerfile.circle
@@ -1,4 +1,5 @@
 FROM php:7.2-cli
+ARG GOJQ_VERSION=0.12.4
 
 ENV COMPOSER_ALLOW_SUPERUSER=1 \
     DOCKER_VERSION=19.03.8 \
@@ -37,7 +38,7 @@ RUN curl -L -o /tmp/hub.tgz https://github.com/github/hub/releases/download/v$HU
     && mv /tmp/hub-linux-amd64-$HUB_VERSION/bin/* /usr/bin
 
 # Install gojq.
-RUN curl -L https://github.com/itchyny/gojq/releases/download/v0.11.2/gojq_v0.11.2_linux_amd64.tar.gz --output /tmp/gojq_v0.11.2_linux_amd64.tar.gz && \
-    tar -C /tmp -xvf /tmp/gojq_v0.11.2_linux_amd64.tar.gz && \
-    chmod +x /tmp/gojq_v0.11.2_linux_amd64/gojq && \
-    mv /tmp/gojq_v0.11.2_linux_amd64/gojq /usr/local/bin
+RUN curl -L https://github.com/itchyny/gojq/releases/download/v${GOJQ_VERSION}/gojq_v${GOJQ_VERSION}_linux_amd64.tar.gz --output /tmp/gojq_v${GOJQ_VERSION}_linux_amd64.tar.gz && \
+    tar -C /tmp -xvf /tmp/gojq_v${GOJQ_VERSION}_linux_amd64.tar.gz && \
+    chmod +x /tmp/gojq_v${GOJQ_VERSION}_linux_amd64/gojq && \
+    mv /tmp/gojq_v${GOJQ_VERSION}_linux_amd64/gojq /usr/local/bin


### PR DESCRIPTION
### Issues
`gojq` fixed slurp option with JSON file arguments issue at [0.12.0 version](https://github.com/itchyny/gojq/releases/tag/v0.12.0), which is really important for doing  json files merging.

###  Changes
1. updates `gojq` to latest version 0.12.4