### PR TITLE
[DDS-917]: Add nginx section health listener.

### DIFF
--- a/bay/images/Dockerfile.nginx
+++ b/bay/images/Dockerfile.nginx
@@ -12,6 +12,9 @@ COPY nginx/helpers/ /etc/nginx/helpers/
 COPY nginx/prepend/ /etc/nginx/conf.d/drupal/
 COPY nginx/content /etc/nginx/conf.d/drupal/content
 
+# Add server append directives.
+COPY nginx/append/server_append-healthz.conf /etc/nginx/conf.d/drupal/server_append-healthz.conf
+
 RUN fix-permissions /etc/nginx \
     && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
     && echo $TZ > /etc/timezone

--- a/bay/images/nginx/append/server_append-healthz.conf
+++ b/bay/images/nginx/append/server_append-healthz.conf
@@ -1,0 +1,13 @@
+
+#
+# Fast section health check listener.
+#
+# Section have implemented health probes that hit bypass all caching
+# layers and hit origin - this genrally gets routed via index.php
+# and causes application bootstraps which ultimately end up resolve
+# to a 404.
+#
+location /.well-known/section-io/aee-hc/healthz {
+  add_header Content-Type text/plain;
+  return 200 'okay';
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,10 @@ services:
       args:
         << : *default-args
     image: ${DOCKERHUB_NAMESPACE:-singledigital}/nginx
+    ports:
+      - 8080
+    depends_on:
+      - php
     environment:
       << : *default-environment
     networks:


### PR DESCRIPTION
- Adds location support for Sections health probe

```
 $ http -h http://localhost:64841/.well-known/section-io/aee-hc/healthz
HTTP/1.1 200 OK

$ time http http://localhost:64841/.well-known/section-io/aee-hc/healthz
http http://localhost:64841/.well-known/section-io/aee-hc/healthz  0.23s user 0.07s system 72% cpu 0.416 total
```
