### PR TITLE
Bay Drupal settings.php fixes

### DIFF
--- a/bay/images/docker/settings.php
+++ b/bay/images/docker/settings.php
@@ -69,7 +69,10 @@ $settings['update_free_access'] = FALSE;
 // so it cannot be read via the browser. If your Drupal root is inside a
 // subfolder (like 'web') you can put the config folder outside this subfolder
 // for an advanced security measure: '../config/sync'.
-$config_directories[CONFIG_SYNC_DIRECTORY] = '../config/sync';
+if (defined('CONFIG_SYNC_DIRECTORY')) {
+  $config_directories[CONFIG_SYNC_DIRECTORY] = '../config/sync';
+}
+$settings['config_sync_directory'] = '../config/sync';
 
 // The default list of directories that will be ignored by Drupal's file API.
 $settings['file_scan_ignore_directories'] = [

--- a/bay/images/docker/settings.php
+++ b/bay/images/docker/settings.php
@@ -127,7 +127,7 @@ if (getenv('ENABLE_REDIS')) {
       $redis_interface = getenv('REDIS_INTERFACE');
     }
 
-    if (strpos($redis->ping(), 'PONG') === 'FALSE') {
+    if (strpos($redis->ping(), 'PONG') === FALSE) {
       throw new \Exception('Redis reachable but is not responding correctly.');
     }
 

--- a/bay/images/docker/settings.php
+++ b/bay/images/docker/settings.php
@@ -2,7 +2,18 @@
 
 /**
  * @file
- * Bay Drupal 8 configuration file.
+ * Bay Drupal configuration file.
+ *
+ * @var string $app_root
+ *   The path to the application root.
+ * @var string $site_path
+ *   The active site directory for a request, relative to '$app_root'.
+ * @var array $databases
+ *   The database connections that Drupal may use.
+ * @var array $settings
+ *   Settings for read-only, low bootstrap, environment specific configuration.
+ * @var array $config
+ *   Configuration overrides.
  */
 
 $bay_settings_path = __DIR__;


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Explain the **details** for making this change. What existing problem does the pull request solve?

1. Document the available Drupal globals referenced in Bay settings.php
2. Fix a logic error in the Redis connection settings, when Redis is reachable but not responding correctly. The fixed expression was using an exact match operand with a string, but the return type from `strpos` would always be either a boolean or integer. As such, this expression would never return true, and the following statements were never evaluated.
3. Update to config sync directories applied for Drupal 8.8 and Drupal 9 where the deprecated constant `CONFIG_SYNC_DIRECTORY` is removed.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->

Bugfix - Drupal settings.php fixes for Redis and config sync directory

# Closing issues

No issues raised.

