### PR TITLE
Added --no-cache flag to buildx bake command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ jobs:
             docker buildx inspect --bootstrap
       - run:
           name: Prepare the manifest
-          command: IMAGE_TAG=$(.circleci/scripts/tag.sh) docker buildx bake -f bake.hcl --print
+          command: IMAGE_TAG=$(.circleci/scripts/tag.sh) docker buildx bake -f bake.hcl --print --no-cache
       - run:
           name: Build the images
-          command: IMAGE_TAG=$(.circleci/scripts/tag.sh) docker buildx bake -f bake.hcl
+          command: IMAGE_TAG=$(.circleci/scripts/tag.sh) docker buildx bake -f bake.hcl --no-cache
       - run:
           name: Start the containers
           command: IMAGE_TAG=$(.circleci/scripts/tag.sh) docker-compose up -d
@@ -74,7 +74,7 @@ jobs:
               echo "==> Skip deployment..."
             else
               echo "==> Push images with $IMAGE_TAG"
-              IMAGE_TAG=$(.circleci/scripts/tag.sh) docker buildx bake -f bake.hcl --push
+              IMAGE_TAG=$(.circleci/scripts/tag.sh) docker buildx bake -f bake.hcl --push --no-cache
               echo "==> Push the AWX Executor Environment image"
               ansible-builder build --context=bay/images/awx-ee/context --tag singledigital/awx-ee:$(.circleci/scripts/tag.sh) --container-runtime docker -f bay/images/awx-ee/execution-environment.yml
               docker push singledigital/awx-ee:$(.circleci/scripts/tag.sh)


### PR DESCRIPTION
Attempting to fix an issue with public base images not being updated.

For example, in bay-ci-builder we install `terraform` by copying it from the `terraform:light` base image. But the version in our image is currently several months old.

When I built the image locally it was using the latest version of terraform.