### PR TITLE
Fixed boolean handling of ENABLE_SMTP envvar.

### DIFF
--- a/bay/images/docker/settings.php
+++ b/bay/images/docker/settings.php
@@ -174,7 +174,7 @@ $config['system.performance']['css']['preprocess'] = 1;
 // Aggregate JavaScript files on
 $config['system.performance']['js']['preprocess'] = 1;
 
-if ($smtp_on = getenv('ENABLE_SMTP')) {
+if ($smtp_on = getenv('ENABLE_SMTP') == "true") {
   $config['smtp.settings']['smtp_on'] = (strtolower($smtp_on) == "true");
   $config['smtp.settings']['smtp_host'] = getenv('SMTP_HOST') ?: 'email-smtp.ap-southeast-2.amazonaws.com';
   $config['smtp.settings']['smtp_port'] = getenv('SMTP_PORT') ?: '587';


### PR DESCRIPTION
Ensures if a project has ENABLE_SMTP=false, the feature isn't unintentionally enabled.