### PR TITLE
Increase ansible-builder verbosity.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           command: IMAGE_TAG=$(.circleci/scripts/tag.sh) tests/run.sh
       - run:
           name: Build the AWX EE
-          command: ansible-builder build --context=bay/images/awx-ee/context --tag singledigital/awx-ee:latest --container-runtime docker -f bay/images/awx-ee/execution-environment.yml
+          command: ansible-builder build --verbosity 3 --context=bay/images/awx-ee/context --tag singledigital/awx-ee:latest --container-runtime docker -f bay/images/awx-ee/execution-environment.yml
 
 
 
@@ -104,7 +104,7 @@ jobs:
               echo "==> Push images with $IMAGE_TAG"
               IMAGE_TAG=$(.circleci/scripts/tag.sh) docker buildx bake -f bake.hcl --push --no-cache
               echo "==> Push the AWX Executor Environment image"
-              ansible-builder build --context=bay/images/awx-ee/context --tag singledigital/awx-ee:$(.circleci/scripts/tag.sh) --container-runtime docker -f bay/images/awx-ee/execution-environment.yml
+              ansible-builder build --verbosity 3 --context=bay/images/awx-ee/context --tag singledigital/awx-ee:$(.circleci/scripts/tag.sh) --container-runtime docker -f bay/images/awx-ee/execution-environment.yml
               docker push singledigital/awx-ee:$(.circleci/scripts/tag.sh)
             fi
 workflows:


### PR DESCRIPTION
CircleCI jobs sometimes fail with the following:
```
Too long with no output (exceeded 10m0s): context deadline exceeded
```
Increasing the verbosity will hopefully help with that.