### PR TITLE
Correctly configure Drupal's system.mail config for SMTP.

### DIFF
--- a/images/bay-php/settings.php
+++ b/images/bay-php/settings.php
@@ -174,8 +174,8 @@ $config['system.performance']['css']['preprocess'] = 1;
 // Aggregate JavaScript files on
 $config['system.performance']['js']['preprocess'] = 1;
 
-if ($smtp_on = getenv('ENABLE_SMTP')) {
-  $config['smtp.settings']['smtp_on'] = (strtolower($smtp_on) == "true");
+if (strlower(getenv('ENABLE_SMTP')) === "true") {
+  $config['system.mail']['interface']['default'] = 'SMTPMailSystem';
   $config['smtp.settings']['smtp_host'] = getenv('SMTP_HOST') ?: 'email-smtp.ap-southeast-2.amazonaws.com';
   $config['smtp.settings']['smtp_port'] = getenv('SMTP_PORT') ?: '587';
   $config['smtp.settings']['smtp_protocol'] = getenv('SMTP_PROTOCOL') ?: 'tls';
@@ -184,7 +184,7 @@ if ($smtp_on = getenv('ENABLE_SMTP')) {
   $config['smtp.settings']['smtp_timeout'] = getenv('SMTP_TIMEOUT') ?: 15;
 
   // @see baywatch.module for SMTP_REPLYTO setting.
-  $config['system.site']['mail'] = getenv('SMTP_FROM') ?: 'admin@vic.gov.au';
+  $config['system.site']['mail'] = getenv('SMTP_FROM') ?: 'admin@dpc.vic.gov.au';
 }
 
 /**


### PR DESCRIPTION
## Problem

The current setup for configuring SMTP module in `/bay/settings.php` does not work - mail still goes via the amazee MTA.

## Solution

This PR makes changes which tells Drupal to use the SMTP transport when the `ENABLE_SMTP` variable is set.

## Notes

Credit to @RonaldRinaldy who helped debug this issue.