### PR TITLE
[DDS-1589][DDS-1576][skip ci] Added temp workaround for builder issues.

### DIFF
--- a/images/awx-ee-ansible-runner-base/Dockerfile
+++ b/images/awx-ee-ansible-runner-base/Dockerfile
@@ -1,0 +1,11 @@
+FROM ghcr.io/dpc-sdp/bay/awx-ee:5.x-ansible-runner-base
+
+COPY ./requirements.yml /tmp
+WORKDIR /tmp
+
+RUN ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 ansible-galaxy collection install -r requirements.yml --collections-path "/usr/share/ansible/collections" -vvv
+
+LABEL ansible-execution-environment=true
+
+
+

--- a/images/awx-ee-ansible-runner-base/requirements.yml
+++ b/images/awx-ee-ansible-runner-base/requirements.yml
@@ -1,0 +1,13 @@
+---
+collections:
+  - ansible.posix
+  - ansible.utils
+  - awx.awx
+  - community.general
+  - kubernetes.core
+  - name: https://github.com/salsadigitalauorg/lagoon_ansible_collection.git
+    version: master
+    type: git
+  - name: https://github.com/salsadigitalauorg/section_ansible_collection.git
+    version: main
+    type: git


### PR DESCRIPTION
Added a Dockerfile to build a point-in-time (known working) version of the EE but also facilitate updates to Ansible Collections so we can pull in updates.

This should not be necessary once DDS-1576 is resolved.

