### PR TITLE
Reinstated DRUPAL_HASH_SALT envvar

### DIFF
--- a/images/bay-php/settings.php
+++ b/images/bay-php/settings.php
@@ -257,9 +257,11 @@ if (getenv("BAY_SHARED_TEMP_FILES") == "true") {
 } else {
   $settings['file_temp_path'] = getenv("TMPDIR") ?: "/tmp";
 }
-
 // Hash Salt.
-$settings['hash_salt'] = hash('sha256', getenv('LAGOON_PROJECT'));
+$settings['hash_salt'] = getenv('DRUPAL_HASH_SALT');
+if (empty($settings['hash_salt'])) {
+  throw new \Exception('DRUPAL_HASH_SALT missing.');
+}
 
 // Configure platformwide cache tag blacklists.
 // These will be excluded when Drupal outputs the cache tag list


### PR DESCRIPTION
This was done in #6 but got lost a long time ago

Related PRs
- https://github.com/dpc-sdp/sdp-cmdb/pull/1187
- #6 

## Motivation

Back in 2020 we implemented a security fix that was changing Drupal's hash salt from a deterministic value, to a random value. Unfortunately this change was lost when the current bay image versioning scheme was put in place.

This PR reinstates the changes found in #6 