### PR TITLE
Patch ci-builder image

### DIFF
--- a/images/ci-builder/Dockerfile
+++ b/images/ci-builder/Dockerfile
@@ -1,9 +1,9 @@
 FROM hashicorp/terraform:light AS terraform
-FROM php:7.4-cli-alpine
-ARG AHOY_VERSION=2.0.0
+FROM php:8.1-cli-alpine
+ARG AHOY_VERSION=2.1.1
 ARG GOJQ_VERSION=0.12.4
 ARG HUB_VERSION=2.14.2
-ARG LAGOON_CLI_VERSION=0.10.0
+ARG LAGOON_CLI_VERSION=v0.19.0
 
 # Ensure temp files dont end up in image.
 VOLUME /tmp
@@ -61,7 +61,7 @@ RUN apk add --no-cache \
     && docker-php-ext-install -j$(nproc) gd
 
 # Install Lagoon CLI.
-RUN curl -L "https://github.com/amazeeio/lagoon-cli/releases/download/${LAGOON_CLI_VERSION}/lagoon-cli-${LAGOON_CLI_VERSION}-linux-amd64" -o /usr/local/bin/lagoon && \
+RUN curl -L "https://github.com/uselagoon/lagoon-cli/releases/download/${LAGOON_CLI_VERSION}/lagoon-cli-${LAGOON_CLI_VERSION}-linux-amd64" -o /usr/local/bin/lagoon && \
     chmod +x /usr/local/bin/lagoon
 RUN lagoon config feature --disable-project-directory-check true
 
@@ -78,7 +78,7 @@ RUN curl -L -o "/usr/local/bin/ahoy" "https://github.com/ahoy-cli/ahoy/releases/
   && ahoy --version
 
 # Install bats and shellcheck.
-RUN npm install -g bats@1.2.1
+RUN npm install -g bats@1.10.0
 RUN apk add --no-cache shellcheck
 
 # Cleanup tmp when we're done.


### PR DESCRIPTION
## Changes

- Bumps `ci-builder` base image to `php:8.1-cli-alpine`
- Bumps versions of installed utilities.

Fixes #200 