### PR TITLE
Added db-dump-sanitized.sh script

### DIFF
--- a/images/php/Dockerfile.cli
+++ b/images/php/Dockerfile.cli
@@ -39,6 +39,7 @@ COPY redis-cluster.services.yml /bay
 COPY redis-single.services.yml /bay
 COPY settings.php /bay
 COPY db-build.sh /bay
+COPY db-dump-sanitized.sh /bay
 COPY mtk /bay/mtk
 
 # Change worker pool from dynamic to static. Change default value to 24.

--- a/images/php/db-build.sh
+++ b/images/php/db-build.sh
@@ -26,12 +26,7 @@ cleanup() {
 if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
   trap cleanup EXIT
   info "creating sanitized database dump with mtk - https://github.com/skpr/mtk"
-  mtk dump \
-    --user "${MARIADB_USERNAME}" \
-    --password "${MARIADB_PASSWORD}" \
-    --port "${MARIADB_PORT}" \
-    --host "${MARIADB_HOST}" \
-    "${MARIADB_DATABASE}" > "${DB_TEMPORARY_FILE}" || fatal "failed to dump database"
+  /bay/db-dump-sanitized.sh > "${DB_TEMPORARY_FILE}" || fatal "failed to dump database"
 
   info "pushing database dump to s3 - ${S3_OBJECT_PATH}"
   aws s3 cp --no-progress "${DB_TEMPORARY_FILE}" "${S3_OBJECT_PATH}" || fatal "failed to push dump to s3"

--- a/images/php/db-dump-sanitized.sh
+++ b/images/php/db-dump-sanitized.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+#/ Usage:       ./db-dump-sanitized.sh
+#/ Description: dumps a sanitized database to stdout
+#/ Options:
+#/   --help: Display this help message
+usage() { grep '^#/' "$0" | cut -c4- ; exit 0 ; }
+expr "$*" : ".*--help" > /dev/null && usage
+
+mtk dump \
+  --user "${MARIADB_USERNAME}" \
+  --password "${MARIADB_PASSWORD}" \
+  --port "${MARIADB_PORT}" \
+  --host "${MARIADB_HOST}" \
+  "${MARIADB_DATABASE}"


### PR DESCRIPTION
## Motivation

Splitting the db dump command into its own script allows us to call it from different places more easily.