### PR TITLE
[DDS-1871] Updated default user home path.

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -62,6 +62,14 @@ jobs:
             --verbosity 3
         working-directory: ./images/awx-ee
 
+      - name: Upload AWX-EE context for review
+        if: matrix.images == 'awx-ee'
+        uses: actions/upload-artifact@v4
+        with:
+          name: awx-ee-context
+          path: ./images/awx-ee/context
+          retention-days: 1
+
       - name: Build and push the images
         uses: docker/bake-action@v3.1.0
         with:

--- a/images/awx-ee/execution-environment.yml
+++ b/images/awx-ee/execution-environment.yml
@@ -68,8 +68,6 @@ additional_build_steps:
     - RUN tar -C /tmp -xvf /tmp/gojq_v0.12.4_linux_amd64.tar.gz
     - RUN chmod +x /tmp/gojq_v0.12.4_linux_amd64/gojq
     - RUN mv /tmp/gojq_v0.12.4_linux_amd64/gojq /usr/local/bin
-    - RUN touch /runner/.bashrc && chmod +x /runner/.bashrc
-    - RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_INSTALL_VERSION/install.sh | bash
     - RUN curl -L "https://get.helm.sh/helm-v3.12.2-linux-amd64.tar.gz" -o /tmp/helm && tar -xvf /tmp/helm -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin
     - RUN chmod +x /usr/local/bin/helm
     - RUN curl -L https://github.com/google/yamlfmt/releases/download/v0.10.0/yamlfmt_0.10.0_Linux_x86_64.tar.gz --output /tmp/yamlfmt_0.10.0_Linux_x86_64.tar.gz
@@ -84,3 +82,6 @@ additional_build_steps:
         && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
         && apt update \
         && DEBIAN_FRONTEND=noninteractive apt install gh -y
+    - USER 1000
+    - RUN touch $HOME/.bashrc && chmod +x $HOME/.bashrc
+    - RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_INSTALL_VERSION/install.sh | bash

--- a/images/awx-ee/execution-environment.yml
+++ b/images/awx-ee/execution-environment.yml
@@ -71,7 +71,7 @@ additional_build_steps:
     - RUN mv /tmp/gojq_v0.12.4_linux_amd64/gojq /usr/local/bin
     - RUN touch /runner/.bashrc && chmod +x /runner/.bashrc
     - RUN mkdir -p /runner/.nvm && chgrp 0 /runner/.nvm && chmod -R ug+rwx /runner/.nvm
-    - RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_INSTALL_VERSION/install.sh | bash
+    - RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_INSTALL_VERSION/install.sh | PROFILE="/runner/.bashrc" bash
     - RUN curl -L "https://get.helm.sh/helm-v3.12.2-linux-amd64.tar.gz" -o /tmp/helm && tar -xvf /tmp/helm -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin
     - RUN chmod +x /usr/local/bin/helm
     - RUN curl -L https://github.com/google/yamlfmt/releases/download/v0.10.0/yamlfmt_0.10.0_Linux_x86_64.tar.gz --output /tmp/yamlfmt_0.10.0_Linux_x86_64.tar.gz

--- a/images/awx-ee/execution-environment.yml
+++ b/images/awx-ee/execution-environment.yml
@@ -29,6 +29,7 @@ additional_build_steps:
     - ARG NODE_VERSION=v14.15.1
 
   append_final:
+    - ARG NVM_DIR="/runner/.nvm"
     - | # Required dependencies.
       RUN set -eux; \
           apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -68,6 +69,8 @@ additional_build_steps:
     - RUN tar -C /tmp -xvf /tmp/gojq_v0.12.4_linux_amd64.tar.gz
     - RUN chmod +x /tmp/gojq_v0.12.4_linux_amd64/gojq
     - RUN mv /tmp/gojq_v0.12.4_linux_amd64/gojq /usr/local/bin
+    - RUN touch $HOME/.bashrc && chmod +x $HOME/.bashrc
+    - RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_INSTALL_VERSION/install.sh | bash
     - RUN curl -L "https://get.helm.sh/helm-v3.12.2-linux-amd64.tar.gz" -o /tmp/helm && tar -xvf /tmp/helm -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin
     - RUN chmod +x /usr/local/bin/helm
     - RUN curl -L https://github.com/google/yamlfmt/releases/download/v0.10.0/yamlfmt_0.10.0_Linux_x86_64.tar.gz --output /tmp/yamlfmt_0.10.0_Linux_x86_64.tar.gz
@@ -82,6 +85,3 @@ additional_build_steps:
         && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
         && apt update \
         && DEBIAN_FRONTEND=noninteractive apt install gh -y
-    - RUN touch $HOME/.bashrc && chmod +x $HOME/.bashrc
-    - USER 1000
-    - RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_INSTALL_VERSION/install.sh | bash

--- a/images/awx-ee/execution-environment.yml
+++ b/images/awx-ee/execution-environment.yml
@@ -27,7 +27,7 @@ additional_build_steps:
     - ARG LAGOON_CLI_VERSION=v0.15.4
     - ARG NVM_INSTALL_VERSION=v0.39.7
     - ARG NODE_VERSION=v18.17.0
-    - ARG NVM_DIR="/runner"
+    - ARG NVM_DIR="/runner/.nvm"
 
   append_final:
     - | # Required dependencies.
@@ -70,6 +70,7 @@ additional_build_steps:
     - RUN chmod +x /tmp/gojq_v0.12.4_linux_amd64/gojq
     - RUN mv /tmp/gojq_v0.12.4_linux_amd64/gojq /usr/local/bin
     - RUN touch /runner/.bashrc && chmod +x /runner/.bashrc
+    - RUN mkdir -p /runner/.nvm && chgrp 0 /runner/.nvm && chmod -R ug+rwx /runner/.nvm
     - RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_INSTALL_VERSION/install.sh | bash
     - RUN curl -L "https://get.helm.sh/helm-v3.12.2-linux-amd64.tar.gz" -o /tmp/helm && tar -xvf /tmp/helm -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin
     - RUN chmod +x /usr/local/bin/helm

--- a/images/awx-ee/execution-environment.yml
+++ b/images/awx-ee/execution-environment.yml
@@ -82,6 +82,6 @@ additional_build_steps:
         && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
         && apt update \
         && DEBIAN_FRONTEND=noninteractive apt install gh -y
-    - USER 1000
     - RUN touch $HOME/.bashrc && chmod +x $HOME/.bashrc
+    - USER 1000
     - RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_INSTALL_VERSION/install.sh | bash

--- a/images/awx-ee/execution-environment.yml
+++ b/images/awx-ee/execution-environment.yml
@@ -68,7 +68,7 @@ additional_build_steps:
     - RUN tar -C /tmp -xvf /tmp/gojq_v0.12.4_linux_amd64.tar.gz
     - RUN chmod +x /tmp/gojq_v0.12.4_linux_amd64/gojq
     - RUN mv /tmp/gojq_v0.12.4_linux_amd64/gojq /usr/local/bin
-    - RUN touch $HOME/.bashrc && chmod +x $HOME/.bashrc
+    - RUN touch /runner/.bashrc && chmod +x /runner/.bashrc
     - RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_INSTALL_VERSION/install.sh | bash
     - RUN curl -L "https://get.helm.sh/helm-v3.12.2-linux-amd64.tar.gz" -o /tmp/helm && tar -xvf /tmp/helm -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin
     - RUN chmod +x /usr/local/bin/helm

--- a/images/awx-ee/execution-environment.yml
+++ b/images/awx-ee/execution-environment.yml
@@ -25,11 +25,11 @@ additional_build_steps:
     - LABEL org.opencontainers.image.description="Provides an AWX execution environment image optimised for use with SDP. Built with ansible-builder."
     - LABEL org.opencontainers.image.source="https://github.com/dpc-sdp/bay/blob/6.x/images/awx-ee/"
     - ARG LAGOON_CLI_VERSION=v0.15.4
-    - ARG NVM_INSTALL_VERSION=v0.39.1
-    - ARG NODE_VERSION=v14.15.1
+    - ARG NVM_INSTALL_VERSION=v0.39.7
+    - ARG NODE_VERSION=v18.17.0
+    - ARG NVM_DIR="/runner"
 
   append_final:
-    - ARG NVM_DIR="/runner/.nvm"
     - | # Required dependencies.
       RUN set -eux; \
           apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -69,7 +69,7 @@ additional_build_steps:
     - RUN tar -C /tmp -xvf /tmp/gojq_v0.12.4_linux_amd64.tar.gz
     - RUN chmod +x /tmp/gojq_v0.12.4_linux_amd64/gojq
     - RUN mv /tmp/gojq_v0.12.4_linux_amd64/gojq /usr/local/bin
-    - RUN touch $HOME/.bashrc && chmod +x $HOME/.bashrc
+    - RUN touch /runner/.bashrc && chmod +x /runner/.bashrc
     - RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_INSTALL_VERSION/install.sh | bash
     - RUN curl -L "https://get.helm.sh/helm-v3.12.2-linux-amd64.tar.gz" -o /tmp/helm && tar -xvf /tmp/helm -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin
     - RUN chmod +x /usr/local/bin/helm


### PR DESCRIPTION
### Changes
1. Updates install process so nvm is available to user `1000` (home dir `/runner`)
2. Sets the default node version to [18.7.0 LTS](https://nodejs.org/en/blog/release/v18.17.0)
3. Adds a step to the workflow to upload the ansible-builder context to help with review/debugging