### PR TITLE
fix: pinned versions for gql requirements

### DIFF
--- a/images/awx-ee/requirements.txt
+++ b/images/awx-ee/requirements.txt
@@ -8,10 +8,11 @@ yamllint
 kubernetes
 lxml
 gql
-# Dependencies for the gql requests transport.
-requests-toolbelt<1,>=0.9.1
-urllib3>=1.26
-requests<3,>=2.26
 ruamel.yaml
 pygithub
 azure-cli
+
+# Dependencies for the gql requests transport.
+requests<3,>=2.26
+requests-toolbelt<1,>=0.10.1
+urllib3<2.0.0


### PR DESCRIPTION
Bugfix - Pinned versions for gql python requirements - requests 3 does not work with urllib3 > 2.0.0, which was causing Lagoon API calls from the Lagoon Ansible Collection to fail, so the dependencies have been pinned accordingly.

Refer to https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli and https://github.com/kubeflow/pipelines/pull/9323/files for additional information.
