### PR TITLE
[SDPSUP-7185] Update search endpoints to use http

### DIFF
--- a/images/php/settings.php
+++ b/images/php/settings.php
@@ -319,7 +319,7 @@ $config['clamav.settings']['mode_daemon_tcpip']['port'] = $clamav_port;
 
 // Configure elasticsearch connections from environment variables.
 if (getenv('SEARCH_HASH') && getenv('SEARCH_URL')) {
-  $config['elasticsearch_connector.cluster.elasticsearch_bay']['url'] = sprintf('http://%s.%s', getenv('SEARCH_HASH'), getenv('SEARCH_URL'));
+  $config['elasticsearch_connector.cluster.elasticsearch_bay']['url'] = sprintf('https://%s.%s', getenv('SEARCH_HASH'), getenv('SEARCH_URL'));
 } else {
   $config['elasticsearch_connector.cluster.elasticsearch_bay']['url'] =  "http://elasticsearch:9200";
 }

--- a/images/php/settings.php
+++ b/images/php/settings.php
@@ -319,7 +319,7 @@ $config['clamav.settings']['mode_daemon_tcpip']['port'] = $clamav_port;
 
 // Configure elasticsearch connections from environment variables.
 if (getenv('SEARCH_HASH') && getenv('SEARCH_URL')) {
-  $config['elasticsearch_connector.cluster.elasticsearch_bay']['url'] = sprintf('https://%s.%s', getenv('SEARCH_HASH'), getenv('SEARCH_URL'));
+  $config['elasticsearch_connector.cluster.elasticsearch_bay']['url'] = sprintf('http://%s.%s', getenv('SEARCH_HASH'), getenv('SEARCH_URL'));
 } else {
   $config['elasticsearch_connector.cluster.elasticsearch_bay']['url'] =  "http://elasticsearch:9200";
 }
@@ -347,7 +347,7 @@ if (getenv('SEARCH_AUTH_USERNAME') && getenv('SEARCH_AUTH_PASSWORD')) {
 }
 
 // Override data_pipelines url.
-$config['data_pipelines.dataset_destination.sdp_elasticsearch']['destinationSettings']['url'] = (getenv('SEARCH_HASH') && getenv('SEARCH_URL')) ? sprintf('https://%s.%s', getenv('SEARCH_HASH'), getenv('SEARCH_URL')) : "http://elasticsearch:9200";
+$config['data_pipelines.dataset_destination.sdp_elasticsearch']['destinationSettings']['url'] = (getenv('SEARCH_HASH') && getenv('SEARCH_URL')) ? sprintf('http://%s.%s', getenv('SEARCH_HASH'), getenv('SEARCH_URL')) : "http://elasticsearch:9200";
 
 // Configure tide_logs.
 if (getenv('TIDE_LOGS_UDPLOG_HOST')) {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->

# Changelog Entry
Updates the computed Elasticsearch endpoint used for data_pipelines to use the http protocol. This is required because the endpoint is internal to the Kubernetes cluster which does not have certificates issued for the sdp-elastic pods.
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->

Tested in https://github.com/dpc-sdp/content-reference-sdp-vic-gov-au/pull/403

### screenshots
From PR env - https://nginx-php.pr-403.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au

<img width="1424" alt="Screenshot 2024-05-22 at 8 13 43 AM" src="https://github.com/dpc-sdp/bay/assets/3916040/5043ddbd-48bf-4e46-941a-d9a41efdf9d8">
<img width="1424" alt="Screenshot 2024-05-22 at 8 13 55 AM" src="https://github.com/dpc-sdp/bay/assets/3916040/0c9f2cb7-7fe1-4643-b240-b8b16200a50c">
