### PR TITLE
Added section-io-id to nginx log output

### DIFF
--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -19,6 +19,7 @@ COPY content /etc/nginx/conf.d/drupal/content
 
 # Add server append directives.
 COPY append/server_append-healthz.conf /etc/nginx/conf.d/drupal/server_append-healthz.conf
+COPY append/http-log-format.conf /etc/nginx/conf.d/http-log-format.conf
 
 RUN fix-permissions /etc/nginx \
     && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \

--- a/images/nginx/append/http-log-format.conf
+++ b/images/nginx/append/http-log-format.conf
@@ -1,0 +1,5 @@
+    log_format sdp  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for" '
+                    '"$http_x_section_io_id"';
+    access_log      /dev/stdout sdp;


### PR DESCRIPTION
# Changes

Adds the `section-io-id` header value to the nginx log output. This may be useful when trying to link log messages across multiple layers of the stack

Logs look like this now -

```
curl -H 'x-section-io-id: abc123' http://127.0.0.1:8080/user/login
```

```
127.0.0.1 - - [19/Aug/2024:03:30:22 +0000] "GET /user/login HTTP/1.1" 302 326 "-" "curl/8.9.0" "-" "abc123"
```