### PR TITLE
Updated dockerize version.

### DIFF
--- a/images/php/Dockerfile.cli
+++ b/images/php/Dockerfile.cli
@@ -4,7 +4,7 @@ FROM ghcr.io/skpr/mtk:v2.0.2 AS mtk
 FROM uselagoon/php-${PHP_VERSION}-cli-drupal:latest
 
 ARG GOJQ_VERSION=0.12.16
-ARG DOCKERIZE_VERSION=v0.6.1
+ARG DOCKERIZE_VERSION=v0.8.0
 ARG BAY_CLI_VERSION=v1.1.3
 
 COPY --from=php-cli /usr/local/bin/phpdbg /usr/local/bin/


### PR DESCRIPTION
I know [I said the version update was managed](https://github.com/dpc-sdp/bay/pull/292#discussion_r1742944217) in another PR but what I missed was the order of merging _mattered_

#292 reverted the fix in #295, this puts it back to the correct value