### PR TITLE
Removed leftover dev setting.

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           matrix: |
             images: ${{ vars.IMAGES }}
-            exclude:
-              - images: mailpit
       - id: setup-matrix
         run: echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
     outputs:


### PR DESCRIPTION
Removes the exclusion of mailpit from scans.

Excluding the mailpit image was necessary during development of [the workflow to test that the branch would trigger __and__ complete successfully](https://github.com/dpc-sdp/bay/actions/runs/10677648118)