### PR TITLE
Add scheduled scans of 5.x and 6.x images

### DIFF
--- a/.github/workflows/vulnerability-scan-schedule-5x.yml
+++ b/.github/workflows/vulnerability-scan-schedule-5x.yml
@@ -1,0 +1,18 @@
+name: vulnerability-scan-schedule-5.x
+run-name: Scheduled CVE vulnerability scan of 5.x published images.
+env:
+  REGISTRY: ghcr.io
+on:
+  schedule:
+    - cron: '0 22 * * 3'
+  workflow_dispatch:
+jobs:
+  vulnerability-scan-schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan for vulnerabilities on 5.x images
+        id: scan
+        uses: dpc-sdp/bay/.github/workflows/vulnerability-scan.yml
+        with:
+          tag: 5.x
+          summary: "Trivy CVE scan of 5.x published images."

--- a/.github/workflows/vulnerability-scan-schedule-6x.yml
+++ b/.github/workflows/vulnerability-scan-schedule-6x.yml
@@ -1,0 +1,18 @@
+name: vulnerability-scan-schedule-6.x
+run-name: Scheduled CVE vulnerability scan of 6.x published images.
+env:
+  REGISTRY: ghcr.io
+on:
+  schedule:
+    - cron: '2 22 * * 3'
+  workflow_dispatch:
+jobs:
+  vulnerability-scan-schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan for vulnerabilities on 6.x images
+        id: scan
+        uses: dpc-sdp/bay/.github/workflows/vulnerability-scan.yml
+        with:
+          tag: 6.x
+          summary: "Trivy CVE scan of 6.x published images."

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -35,17 +35,23 @@ jobs:
         run: echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
     outputs:
         matrix: ${{ steps.setup-matrix.outputs.matrix }}
-  vulnerability-scan:
+  set-sha-ref:
     runs-on: ubuntu-latest
-    needs: setup-matrix
-    strategy:
-      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     steps:
       - name: checkout
         id: checkout
         uses: actions/checkout@main
         with:
           ref: ${{ github.event.inputs.tag }}
+    outputs:
+      ref: ${{ steps.checkout.outputs.ref }}
+      commit: ${{ steps.checkout.outputs.commit }}
+  vulnerability-scan:
+    runs-on: ubuntu-latest
+    needs: [setup-matrix, set-sha-ref]
+    strategy:
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+    steps:
       - name: Scan for vulnerabilities
         id: scan
         uses: crazy-max/ghaction-container-scan@v3
@@ -57,5 +63,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-          ref: ${{ steps.checkout.outputs.ref }}
-          sha: ${{ steps.checkout.outputs.commit }}
+          ref: ${{ needs.set-sha-ref.outputs.ref }}
+          sha: ${{ needs.set-sha-ref.outputs.commit }}

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -9,20 +9,24 @@ on:
         description: 'Summary of the scheduled scan.'
         required: false
         default: 'Trivy CVE scan of published images.'
+      tag:
+        description: 'Tag to scan.'
+        required: false
+        default: '6.x'
 jobs:
   setup-matrix:
     runs-on: ubuntu-latest
     steps:
       - name: Set summary
         run: echo "${{ github.event.inputs.summary }}" >> $GITHUB_STEP_SUMMARY
-      - if: github.ref_name == '5.x'
+      - if: github.event.inputs.tag == '5.x'
         uses: druzsan/setup-matrix@v2
         with:
           matrix: |
             images: ${{ vars.IMAGES }}
             exclude:
               - images: mailpit
-      - if: github.ref_name != '5.x'
+      - if: github.event.inputs.tag != '5.x'
         uses: druzsan/setup-matrix@v2
         with:
           matrix: |
@@ -31,23 +35,21 @@ jobs:
         run: echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
     outputs:
         matrix: ${{ steps.setup-matrix.outputs.matrix }}
-  vulnerability-scan-schedule:
+  vulnerability-scan:
     runs-on: ubuntu-latest
     needs: setup-matrix
     strategy:
       matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.ref }}
       - name: Scan for vulnerabilities
         id: scan
         uses: crazy-max/ghaction-container-scan@v3
         with:
-          image: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.images }}:${{ github.ref_name }}
+          image: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.images }}:${{ github.event.inputs.tag }}
           dockerfile: ./images/${{ matrix.images }}
       - name: Upload SARIF file
         if: ${{ steps.scan.outputs.sarif != '' }}
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
+          ref: ${{ github.event.inputs.tag }}

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -63,5 +63,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-          ref: ${{ needs.set-sha-ref.outputs.ref }}
+          ref: refs/heads/${{ needs.set-sha-ref.outputs.ref }}
           sha: ${{ needs.set-sha-ref.outputs.commit }}

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -41,6 +41,11 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     steps:
+      - name: checkout
+        id: checkout
+        uses: actions/checkout@main
+        with:
+          ref: ${{ github.event.inputs.tag }}
       - name: Scan for vulnerabilities
         id: scan
         uses: crazy-max/ghaction-container-scan@v3
@@ -52,4 +57,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-          ref: ${{ github.event.inputs.tag }}
+          ref: ${{ steps.checkout.outputs.ref }}
+          sha: ${{ steps.checkout.outputs.commit }}


### PR DESCRIPTION
### Motivation
Refactor the trigger for vulnerability scans based on the response from GitHub support and remove the dependency on AWX to trigger the scans.

### Changes
1. Update the upload-sarif action to specify the [ref](https://github.com/github/codeql-action/blob/d8b1697e9a833a1f8cd88c642a6bd8685d3ee856/upload-sarif/action.yml#L16) and [commit](https://github.com/github/codeql-action/blob/d8b1697e9a833a1f8cd88c642a6bd8685d3ee856/upload-sarif/action.yml#L19) the scan results relate to
    * a caveat to this is that the commit will not always relate to the commit that the image was built at i.e. a breaking change on the head of 5.x will fail to build, meaning the commit used to build the image tagged 5.x and the head of the 5.x branch will no longer be the same
2. Adds the checkout action to look up the commit of the tag input
3. Adds specific workflows for the scheduled scans of 5.x and 6.x images

### Related PRs
dpc-sdp/sdp-ansible-playbooks#176