### PR TITLE
Fix reusable workflow references

### DIFF
--- a/.github/workflows/vulnerability-scan-schedule-5x.yml
+++ b/.github/workflows/vulnerability-scan-schedule-5x.yml
@@ -8,11 +8,9 @@ on:
   workflow_dispatch:
 jobs:
   vulnerability-scan-schedule:
+    name: Scan for vulnerabilities on 5.x images
     runs-on: ubuntu-latest
-    steps:
-      - name: Scan for vulnerabilities on 5.x images
-        id: scan
-        uses: "dpc-sdp/bay/.github/workflows/vulnerability-scan.yml@6.x"
-        with:
-          tag: 5.x
-          summary: "Trivy CVE scan of 5.x published images."
+    uses: "dpc-sdp/bay/.github/workflows/vulnerability-scan.yml@6.x"
+    with:
+      tag: 5.x
+      summary: "Trivy CVE scan of 5.x published images."

--- a/.github/workflows/vulnerability-scan-schedule-5x.yml
+++ b/.github/workflows/vulnerability-scan-schedule-5x.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Scan for vulnerabilities on 5.x images
         id: scan
-        uses: dpc-sdp/bay/.github/workflows/vulnerability-scan.yml
+        uses: "dpc-sdp/bay/.github/workflows/vulnerability-scan.yml@6.x"
         with:
           tag: 5.x
           summary: "Trivy CVE scan of 5.x published images."

--- a/.github/workflows/vulnerability-scan-schedule-6x.yml
+++ b/.github/workflows/vulnerability-scan-schedule-6x.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Scan for vulnerabilities on 6.x images
         id: scan
-        uses: dpc-sdp/bay/.github/workflows/vulnerability-scan.yml
+        uses: "dpc-sdp/bay/.github/workflows/vulnerability-scan.yml@6.x"
         with:
           tag: 6.x
           summary: "Trivy CVE scan of 6.x published images."

--- a/.github/workflows/vulnerability-scan-schedule-6x.yml
+++ b/.github/workflows/vulnerability-scan-schedule-6x.yml
@@ -8,11 +8,9 @@ on:
   workflow_dispatch:
 jobs:
   vulnerability-scan-schedule:
+    name: Scan for vulnerabilities on 6.x images
     runs-on: ubuntu-latest
     uses: "dpc-sdp/bay/.github/workflows/vulnerability-scan.yml@6.x"
-    steps:
-      - name: Scan for vulnerabilities on 6.x images
-        id: scan
-        with:
-          tag: 6.x
-          summary: "Trivy CVE scan of 6.x published images."
+    with:
+      tag: 6.x
+      summary: "Trivy CVE scan of 6.x published images."

--- a/.github/workflows/vulnerability-scan-schedule-6x.yml
+++ b/.github/workflows/vulnerability-scan-schedule-6x.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   vulnerability-scan-schedule:
     runs-on: ubuntu-latest
+    uses: "dpc-sdp/bay/.github/workflows/vulnerability-scan.yml@6.x"
     steps:
       - name: Scan for vulnerabilities on 6.x images
         id: scan
-        uses: "dpc-sdp/bay/.github/workflows/vulnerability-scan.yml@6.x"
         with:
           tag: 6.x
           summary: "Trivy CVE scan of 6.x published images."


### PR DESCRIPTION
### Motivation
[Scheduled workflows](https://github.com/dpc-sdp/bay/actions/runs/10820104929) were failing because the call to the reusable workflow was incorrectly implemented.

### Changes
1. Updated scope of `uses` in call to reusable workflow from `job.*.step.uses` to `job.*.uses`