### PR TITLE
Fixed reusable workflow for compatibility with caller workflows.

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -13,6 +13,18 @@ on:
         description: 'Tag to scan.'
         required: false
         default: '6.x'
+  workflow_call:
+    inputs:
+      summary:
+        description: 'Summary of the scheduled scan.'
+        required: false
+        default: 'Trivy CVE scan of published images.'
+        type: string
+      tag:
+        description: 'Tag to scan.'
+        required: false
+        default: '6.x'
+        type: string
 jobs:
   setup-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[Fixes failed scans](https://github.com/dpc-sdp/bay/actions/runs/10824335686) due to the reusable workflow not having the `on.workflow_call` event defined.

```
Invalid workflow file: .github/workflows/vulnerability-scan-schedule-5x.yml#L13
error parsing called workflow
".github/workflows/vulnerability-scan-schedule-5x.yml"
-> "dpc-sdp/bay/.github/workflows/vulnerability-scan.yml@6.x" (source branch with sha:a619839a5e58672894ccef3cec64be399076fdbf)
: workflow is not reusable as it is missing a `on.workflow_call` trigger
```