### PR TITLE
Fixed inputs references

### DIFF
--- a/.github/workflows/vulnerability-scan-schedule-5x.yml
+++ b/.github/workflows/vulnerability-scan-schedule-5x.yml
@@ -6,6 +6,15 @@ on:
   schedule:
     - cron: '0 22 * * 3'
   workflow_dispatch:
+    inputs:
+      summary:
+        description: 'Summary of the scheduled scan.'
+        required: false
+        default: 'Trivy CVE scan of 5.x published images.'
+      tag:
+        description: 'Tag to scan.'
+        required: false
+        default: '5.x'
 jobs:
   vulnerability-scan-schedule:
     name: Scan for vulnerabilities on 5.x images

--- a/.github/workflows/vulnerability-scan-schedule-6x.yml
+++ b/.github/workflows/vulnerability-scan-schedule-6x.yml
@@ -6,6 +6,15 @@ on:
   schedule:
     - cron: '2 22 * * 3'
   workflow_dispatch:
+    inputs:
+      summary:
+        description: 'Summary of the scheduled scan.'
+        required: false
+        default: 'Trivy CVE scan of 6.x published images.'
+      tag:
+        description: 'Tag to scan.'
+        required: false
+        default: '6.x'
 jobs:
   vulnerability-scan-schedule:
     name: Scan for vulnerabilities on 6.x images

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set summary
-        run: echo "${{ inputs.summary }}" >> $GITHUB_STEP_SUMMARY
-      - if: inputs.tag == '5.x'
+        run: echo "${{ github.event.inputs.summary }}" >> $GITHUB_STEP_SUMMARY
+      - if: github.event.inputs.tag == '5.x'
         uses: druzsan/setup-matrix@v2
         with:
           matrix: |
             images: ${{ vars.IMAGES }}
             exclude:
               - images: mailpit
-      - if: inputs.tag != '5.x'
+      - if: github.event.inputs.tag != '5.x'
         uses: druzsan/setup-matrix@v2
         with:
           matrix: |
@@ -54,7 +54,7 @@ jobs:
         id: checkout
         uses: actions/checkout@main
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ github.event.inputs.tag }}
     outputs:
       ref: ${{ steps.checkout.outputs.ref }}
       commit: ${{ steps.checkout.outputs.commit }}
@@ -68,7 +68,7 @@ jobs:
         id: scan
         uses: crazy-max/ghaction-container-scan@v3
         with:
-          image: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.images }}:${{ inputs.tag }}
+          image: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.images }}:${{ github.event.inputs.tag }}
           dockerfile: ./images/${{ matrix.images }}
       - name: Upload SARIF file
         if: ${{ steps.scan.outputs.sarif != '' }}

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set summary
-        run: echo "${{ github.event.inputs.summary }}" >> $GITHUB_STEP_SUMMARY
-      - if: github.event.inputs.tag == '5.x'
+        run: echo "${{ inputs.summary }}" >> $GITHUB_STEP_SUMMARY
+      - if: inputs.tag == '5.x'
         uses: druzsan/setup-matrix@v2
         with:
           matrix: |
             images: ${{ vars.IMAGES }}
             exclude:
               - images: mailpit
-      - if: github.event.inputs.tag != '5.x'
+      - if: inputs.tag != '5.x'
         uses: druzsan/setup-matrix@v2
         with:
           matrix: |
@@ -54,7 +54,7 @@ jobs:
         id: checkout
         uses: actions/checkout@main
         with:
-          ref: ${{ github.event.inputs.tag }}
+          ref: ${{ inputs.tag }}
     outputs:
       ref: ${{ steps.checkout.outputs.ref }}
       commit: ${{ steps.checkout.outputs.commit }}
@@ -68,7 +68,7 @@ jobs:
         id: scan
         uses: crazy-max/ghaction-container-scan@v3
         with:
-          image: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.images }}:${{ github.event.inputs.tag }}
+          image: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.images }}:${{ inputs.tag }}
           dockerfile: ./images/${{ matrix.images }}
       - name: Upload SARIF file
         if: ${{ steps.scan.outputs.sarif != '' }}


### PR DESCRIPTION
The need for this change is mildly infuriating, to the point that I'm questioning if I've configured this correctly.

but without these changes the workflows fail when called via [the GitHub workflows UI because the inputs resolved to](https://github.com/dpc-sdp/bay/actions/runs/10825300033/job/30034038876#step:2:40) `null`

**even though the caller workflow passes the values using the `with` property**