### PR TITLE
Update xdebug modes when xdebug is enabled

### DIFF
--- a/images/php/01-bay.ini
+++ b/images/php/01-bay.ini
@@ -17,3 +17,6 @@ session.sid_length = ${BAY_SESSION_SID_LEN}
 session.sid_bits_per_character = ${BAY_SESSION_SID_BITS}
 
 disable_functions = ${BAY_DISABLE_FUNCTIONS}
+
+[xdebug]
+xdebug.mode = debug,profile


### PR DESCRIPTION
### Motivation
The default configuration in Lagoon images when xdebug is enabled is to only enable the debug mode. This PR also enables the profile mode which will allow a tool such as QCacheGrind (`brew install qcachegrind` on Mac) to analyse and display cachegrind files to identify performance and resource hotspots.

### Changes
1. Update `[xdebug]` PHP config to enable debug and profile modes.

*Note* this change only alters what xdebug does _if_ it is enabled.