### PR TITLE
Added php-fpm_exporter binary and entrypoint script

### DIFF
--- a/images/php/Dockerfile.fpm
+++ b/images/php/Dockerfile.fpm
@@ -34,7 +34,7 @@ RUN chmod +x /tmp/bay
 RUN mv /tmp/bay /bin/bay
 
 # Install php-fpm_exporter
-RUN curl -s -L "https://github.com/hipages/php-fpm_exporter/releases/download/v2.2.0/php-fpm_exporter_${PHP_FPM_EXPORTER_VERSION}_$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '_')" --output /bin/php-fpm_exporter
+RUN curl -s -L "https://github.com/hipages/php-fpm_exporter/releases/download/v${PHP_FPM_EXPORTER_VERSION}/php-fpm_exporter_${PHP_FPM_EXPORTER_VERSION}_$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '_')" --output /bin/php-fpm_exporter
 RUN chmod +x /bin/php-fpm_exporter
 EXPOSE 9253
 

--- a/images/php/Dockerfile.fpm
+++ b/images/php/Dockerfile.fpm
@@ -2,6 +2,7 @@ ARG PHP_VERSION=8.3
 FROM uselagoon/php-${PHP_VERSION}-fpm:latest
 
 ARG BAY_CLI_VERSION=v1.1.3
+ARG PHP_FPM_EXPORTER_VERSION=2.2.0
 
 RUN mkdir /bay
 COPY 01-bay.ini /usr/local/etc/php/conf.d/
@@ -9,6 +10,7 @@ COPY bay-php-config.sh /bay
 
 # Ensure temp dir exists if required
 COPY entrypoints/bay-shared-temp-files-dir-check.sh /lagoon/entrypoints
+COPY entrypoints/bay-php-fpm_exporter.sh /lagoon/entrypoints
 
 # Add common drupal config.
 COPY redis-unavailable.services.yml /bay
@@ -26,10 +28,15 @@ RUN  apk add --no-cache tzdata \
     && echo $TZ > /etc/timezone
 
 # Install bay-cli.
-RUN curl -L "https://github.com/dpc-sdp/bay-cli/releases/download/${BAY_CLI_VERSION}/bay_$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '_').tar.gz" --output /tmp/bay_$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '_').tar.gz
+RUN curl -s -L "https://github.com/dpc-sdp/bay-cli/releases/download/${BAY_CLI_VERSION}/bay_$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '_').tar.gz" --output /tmp/bay_$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '_').tar.gz
 RUN tar -C /tmp -xvf /tmp/bay_$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '_').tar.gz
 RUN chmod +x /tmp/bay
 RUN mv /tmp/bay /bin/bay
+
+# Install php-fpm_exporter
+RUN curl -s -L "https://github.com/hipages/php-fpm_exporter/releases/download/v2.2.0/php-fpm_exporter_${PHP_FPM_EXPORTER_VERSION}_$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '_')" --output /bin/php-fpm_exporter
+RUN chmod +x /bin/php-fpm_exporter
+EXPOSE 9253
 
 ONBUILD ARG BAY_DISABLE_FUNCTIONS=phpinfo,pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,system,exec,shell_exec,passthru,phpinfo,show_source,highlight_file,popen,fopen_with_path,dbmopen,dbase_open,filepro,filepro_rowcount,filepro_retrieve,posix_mkfifo
 ONBUILD ARG BAY_UPLOAD_LIMIT=100M

--- a/images/php/entrypoints/bay-php-fpm_exporter.sh
+++ b/images/php/entrypoints/bay-php-fpm_exporter.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+#/ Usage:       PHP_FPM_EXPORTER_ENABLED=true ./bay-php-fpm_exporter.sh
+#/ Options:
+#/   --help: Display this help message
+usage() { grep '^#/' "$0" | cut -c4- ; exit 0 ; }
+expr "$*" : ".*--help" > /dev/null && usage
+
+echoerr() { printf "%s\n" "$*" >&2 ; }
+info()    { echoerr "[INFO]    $*" ; }
+warning() { echoerr "[WARNING] $*" ; }
+error()   { echoerr "[ERROR]   $*" ; }
+fatal()   { echoerr "[FATAL]   $*" ; exit 1 ; }
+
+if [ "${PHP_FPM_EXPORTER_ENABLED:-false}" = "true" ]; then
+  info starting php-fpm_exporter metrics server
+  php-fpm_exporter server &
+else
+  info php-fpm_exporter metrics server disabled
+fi


### PR DESCRIPTION
# Motivation

We would like to better understand our PHP applications performance characteristics.

# Changes

- Adds the [php-fpm_exporter](https://github.com/hipages/php-fpm_exporter) binary to the php-fpm
- Adds a entrypoint script to the php-fpm image which conditionally starts the php-fpm_metrics binary 
 
# Usage

- Set `PHP_FPM_EXPORTER_ENABLED=true`to run the metrics exporter
- Metrics data should be available at `container-ip:9253/metrics`