### PR TITLE
Added PHP_CLI_MEMORY_LIMIT envvar to configure php cli memory limit

### DIFF
--- a/images/php/Dockerfile.cli
+++ b/images/php/Dockerfile.cli
@@ -46,9 +46,9 @@ COPY db-build.sh /bay
 COPY db-dump-sanitized.sh /bay
 COPY mtk /bay/mtk
 
-# Change worker pool from dynamic to static. Change default value to 24.
-RUN sed -i "s/pm = dynamic/pm = static/" /usr/local/etc/php-fpm.d/www.conf
-ENV PHP_FPM_PM_MAX_CHILDREN=24
+# Provide a separate environment variable to configure the php cli memory limit.
+ENV PHP_CLI_MEMORY_LIMIT=1024M
+RUN sed -i 's/\${PHP_MEMORY_LIMIT:/\${PHP_CLI_MEMORY_LIMIT:/g' "$PHP_INI_DIR/conf.d/00-lagoon-php.ini.tpl"
 
 ARG TZ=Australia/Melbourne
 RUN  apk add --no-cache tzdata \

--- a/images/php/README.md
+++ b/images/php/README.md
@@ -28,17 +28,20 @@ services:
 
 ## Environment Variables
 
-| Name | Default Value | Description |
-|------|---------------|-------------|
-| `BAY_DISABLE_FUNCTIONS` | (see source code) | A list of PHP functions to disable. Security feature to disable potential attack vectors. |
-| `BAY_UPLOAD_LIMIT` | `100M` | Payload size supported by PHP. Synchronises the value across several php configuration elements. |
-| `BAY_POST_MAX` | `100M` |  |
-| `BAY_SESSION_NAME` | `PHPSESSID` |   |
-| `BAY_SESSION_COOKIE_LIFETIME` | `28800` |   |
-| `BAY_SESSION_STRICT` | `1` |   |
-| `BAY_SESSION_SID_LEN` | `256` |   |
-| `BAY_SESSION_SID_BITS` | `6` |   |
+| Name | Default Value     | Description                                                                                      |
+|------|-------------------|--------------------------------------------------------------------------------------------------|
+| `BAY_DISABLE_FUNCTIONS` | (see source code) | A list of PHP functions to disable. Security feature to disable potential attack vectors.        |
+| `BAY_UPLOAD_LIMIT` | `100M`            | Payload size supported by PHP. Synchronises the value across several php configuration elements. |
+| `BAY_POST_MAX` | `100M`            |                                                                                                  |
+| `BAY_SESSION_NAME` | `PHPSESSID`       |                                                                                                  |
+| `BAY_SESSION_COOKIE_LIFETIME` | `28800`           |                                                                                                  |
+| `BAY_SESSION_STRICT` | `1`               |                                                                                                  |
+| `BAY_SESSION_SID_LEN` | `256`             |                                                                                                  |
+| `BAY_SESSION_SID_BITS` | `6`               |                                                                                                  |
+| `PHP_CLI_MEMORY_LIMIT` | `1024M`           | Default memory_limit for CLI container.                                                          |
+| `PHP_FPM_EXPORTER_ENABLED` | `false`           | Toggle for php-fpm metrics exporter.                                                             |
 
 ## Ports
 
 - 9000 - PHP FPM port
+- 9253 - php-fpm_exporter metrics endpoint


### PR DESCRIPTION
## Motivation

After reducing the PHP_MEMORY_LIMIT envvar on content-vic, builds started breaking due to hitting memory limits in the cli container.

## Changes

- Removes fpm worker limit from CLI container (this container doesnt run a fpm processs so its cruft that can be discarded)
- Adds a new envvar `PHP_CLI_MEMORY_LIMIT` that specifically targets the CLI container.
- `PHP_CLI_MEMORY_LIMIT` has a default value of `1024M`
- Adds some missing docs for the metrics exporter.

## Testing

Check out this branch and build image
```
docker build -t test -f Dockerfile.cli .
```
Run the image and check for the memory_limit value.
```
docker run --rm -it -e PHP_CLI_MEMORY_LIMIT=1024M test php -i | grep memory_limit
memory_limit => 1024M => 1024M
docker run --rm -it -e PHP_CLI_MEMORY_LIMIT=-1 test php -i | grep memory_limit
memory_limit => -1 => -1

```