### PR TITLE
Added feature to log the request uri when fatal errors encountered.

### DIFF
--- a/images/php/log-fatals.php
+++ b/images/php/log-fatals.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ *
+ * Adds a shutdown function that logs fatal errors along with the REQUEST_URI.
+ *
+ * Intention is to allow tracking of specific routes that exhaust memory limit.
+ */
+
+/**
+ * Returns a list of error types the custom error handler should respond to.
+ */
+function bay_fatal_error_types() {
+  return [
+    E_ERROR => 'E_ERROR',
+    E_PARSE => 'E_PARSE',
+    E_CORE_ERROR => 'E_CORE_ERROR',
+    E_COMPILE_ERROR => 'E_COMPILE_ERROR',
+  ];
+}
+
+register_shutdown_function(function() {
+  $error = error_get_last();
+  $types = bay_fatal_error_types();
+  if ($error && in_array($error['type'], array_keys($types))) {
+    $data = [
+      'type' => $types[$error['type']],
+      'message' => $error['message'],
+      'request_uri' => $_SERVER['REQUEST_URI'] ?: 'N/A',
+    ];
+    error_log("[BAY_FATAL] " . json_encode($data));
+  }
+});

--- a/images/php/settings.php
+++ b/images/php/settings.php
@@ -21,6 +21,11 @@ $settings_path = $app_root . DIRECTORY_SEPARATOR . 'sites/default';
 $contrib_path = $app_root . DIRECTORY_SEPARATOR . (is_dir('modules/contrib') ? 'modules/contrib' : 'modules');
 $lagoon_env_type = getenv('LAGOON_ENVIRONMENT_TYPE') ?: 'local';
 
+// Feature flag that enables some enhanced logging of fatal errors.
+if (getenv('BAY_PHP_FATAL_LOGS') == "true") {
+  include $bay_settings_path . '/log-fatals.php';
+}
+
 // Database connection.
 $connection_info = [
   'driver' => 'mysql',


### PR DESCRIPTION
## Motivation

We're working on reducing the PHP memory limit to ensure that we can run more concurrent workloads efficiently. There will be a period of tuning where we have to locate some areas of the application which need more memory.

Unfortunately the default php-fpm error logs do not output enough information information for us to determine what drupal routes cause a particular problem.

## Changes

This PR adds a new error handler which outputs a log entry including the value of `$_SERVER['REQUEST_URI']`. This error handling is conditionally included when the following environment variable is set

```
BAY_PHP_FATAL_LOGS=true
```

When hitting a memory exhausted error now, it should output to the php-fpm container's stdout -

```
NOTICE: PHP message: [BAY_FATAL] {"type":"E_ERROR","message":"Allowed memory size of 134217728 bytes exhausted (tried to allocate 1052672 bytes)","request_uri":"\/foo\/bar"}
```

## Testing

Once you've got this code available on your test environment, enable the feature with the above environment variable. You can then hack in this code to settings.php below where the log file is included to induce a memory limit error.

```
ini_set('memory_limit', '128M');

$array = [];
while (true) {
  // Allocate 1MB blocks of memory until the memory limit is exceeded
  $array[] = str_repeat('x', 1024 * 1024);
}
```
