### PR TITLE
Ensure php-fpm-exporter bianry is statically compiled

### DIFF
--- a/images/php-fpm-exporter/Dockerfile
+++ b/images/php-fpm-exporter/Dockerfile
@@ -3,7 +3,7 @@ RUN git clone https://github.com/hipages/php-fpm_exporter.git /workspace
 WORKDIR /workspace
 RUN make deps
 RUN TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}; \
-    GOOS=${TARGETPLATFORM%%/*} GOARCH=${TARGETPLATFORM#*/} go build -o php-fpm-exporter .
+    GOOS=${TARGETPLATFORM%%/*} GOARCH=${TARGETPLATFORM#*/} go build -o php-fpm-exporter -ldflags='-extldflags "-static"' .
 
 FROM gcr.io/distroless/static:nonroot
 LABEL org.opencontainers.image.authors="Single Digital Presence"


### PR DESCRIPTION
<!-- PLEASE UPDATE THIS COTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
## Motivation

Running the binary in php-fpm images was resulting in a `not found` error which can occur when system dependencies are not bundled into the compiled binary.

## Changes

Statically compiles the php-fpm-exporter binary.
