### PR TITLE
Add workaround for az login issues

### DIFF
--- a/images/awx-ee/execution-environment.yml
+++ b/images/awx-ee/execution-environment.yml
@@ -95,3 +95,6 @@ additional_build_steps:
         && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
         && apt update \
         && DEBIAN_FRONTEND=noninteractive apt install gh -y
+    # @todo remove this once following issue resolved
+    # https://github.com/Azure/azure-cli/issues/30102#issuecomment-2427682019
+    - RUN pip install --force-reinstall -v "azure-mgmt-rdbms==10.2.0b17"


### PR DESCRIPTION
## Motivation

Currently, any play that interacts with kubernetes fails on the `az login` step with the following error.

```
Error loading command module 'mysql': cannot import name 'mysql_flexibleservers' from 'azure.mgmt.rdbms' 
Error loading command module 'rdbms': No module named 'azure.mgmt.rdbms.mysql_flexibleservers'
```

## Changes

Adds workaround described in https://github.com/Azure/azure-cli/issues/30102#issuecomment-2427682019

## Testing

This hasnt been tested yet. 
