### PR TITLE
[DDS-2083] Revert change affecting deps

### DIFF
--- a/images/awx-ee/execution-environment.yml
+++ b/images/awx-ee/execution-environment.yml
@@ -95,6 +95,3 @@ additional_build_steps:
         && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
         && apt update \
         && DEBIAN_FRONTEND=noninteractive apt install gh -y
-    # @todo remove this once following issue resolved
-    # https://github.com/Azure/azure-cli/issues/30102#issuecomment-2427682019
-    - RUN pip install --force-reinstall -v "azure-mgmt-rdbms==10.2.0b17"

--- a/images/awx-ee/requirements.yml
+++ b/images/awx-ee/requirements.yml
@@ -7,7 +7,7 @@ collections:
   - kubernetes.core
   - name: lagoon.api
     source: https://github.com/salsadigitalauorg/lagoon_ansible_collection.git
-    version: master
+    version: 1.5.0
     type: git
   - name: section.api
     source: https://github.com/salsadigitalauorg/section_ansible_collection.git


### PR DESCRIPTION
This reverts commit 8f5ae99568b51d256193e788c4b0f99dc542f4ad.

<!-- PLEASE UPDATE THIS COTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
## Motivation
https://digital-vic.atlassian.net/browse/DDS-2083

Fixes AWX failures caused by a dependency update (urllib3).

## Changes
* reverts the change that updated the dependency

## Testing
Before - failed
[Run of CMDB sync-env using awx-ee:pr-335 (no revert, lagoon_ansible_collection 1.5.0)](https://awx.sdp.vic.gov.au/#/jobs/playbook/53319/output)

After - successful
[Run of CMDB sync-env using the awx-ee:pr-331 (rever and lagoon_ansible_collection 1.5.0)](https://awx.sdp.vic.gov.au/#/jobs/playbook/53307)

**nb** The Execution Environment field on the details page of a job does not represent the value at the time of run but the value currently set for the job template.
