### PR TITLE
Pinned lagoon ansible collection version

### DIFF
--- a/images/awx-ee/requirements.yml
+++ b/images/awx-ee/requirements.yml
@@ -7,7 +7,7 @@ collections:
   - kubernetes.core
   - name: lagoon.api
     source: https://github.com/salsadigitalauorg/lagoon_ansible_collection.git
-    version: master
+    version: 1.5.0
     type: git
   - name: section.api
     source: https://github.com/salsadigitalauorg/section_ansible_collection.git


### PR DESCRIPTION
The Lagoon Ansible collection was previously set to use the master branch, which occasionally caused playbook failures. This commit pins the Lagoon Ansible collection to a specific version, providing more stability and reducing the chance of unexpected issues.