### PR TITLE
Bump lagoon.api version to 2.0.0

### DIFF
--- a/images/awx-ee/requirements.yml
+++ b/images/awx-ee/requirements.yml
@@ -7,7 +7,7 @@ collections:
   - kubernetes.core
   - name: lagoon.api
     source: https://github.com/salsadigitalauorg/lagoon_ansible_collection.git
-    version: 1.5.0
+    version: 2.0.0
     type: git
   - name: section.api
     source: https://github.com/salsadigitalauorg/section_ansible_collection.git


### PR DESCRIPTION
<!-- PLEASE UPDATE THIS COTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
## Motivation

Bump lagoon.api version to 2.0.0

## Changes

- Version 2.0.0 renamed `token` plugin to `fetch_token`


