### PR TITLE
Set minimum reporting level of vuln scans to high.

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -71,6 +71,7 @@ jobs:
           image: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.images }}:${{ inputs.tag }}
           dockerfile: ./images/${{ matrix.images }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          severity: HIGH
       - name: Upload SARIF file
         if: ${{ steps.scan.outputs.sarif != '' }}
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
<!-- PLEASE UPDATE THIS COTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
## Motivation
During the weekly CVE scan review our priorities are constrained by time constraints. This means we focus on CVEs of high or greater.

As such we should only report on CVEs that we will action.