### PR TITLE
Unpinned minor version of python in awx-ee image.

### DIFF
--- a/images/awx-ee/execution-environment.yml
+++ b/images/awx-ee/execution-environment.yml
@@ -11,7 +11,7 @@ dependencies:
 
 images:
   base_image:
-    name: python:3.10
+    name: python:3-bookworm
 
 additional_build_steps:
   # Source for those scripts are at https://github.com/ansible/ansible-builder/tree/devel/src/ansible_builder/_target_scripts


### PR DESCRIPTION
<!-- PLEASE UPDATE THIS COTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
## Motivation

Python minor versions were not being updated automatically. The original base image definition also made it unclear what underlying OS was in use.

## Changes

Updated the awx-ee base image tag to `python:3-bookworm` which provides the following benefits:

- python minor versions are automatically upgraded
- unambiguous underlying OS

