### PR TITLE
Add additional xdebug profile settings

### DIFF
--- a/images/php/01-bay.ini
+++ b/images/php/01-bay.ini
@@ -20,3 +20,5 @@ disable_functions = ${BAY_DISABLE_FUNCTIONS}
 
 [xdebug]
 xdebug.mode = debug,profile
+xdebug.output_dir = /app/docroot/sites/default/files/xdebug-profile
+xdebug.use_compression = false


### PR DESCRIPTION
<!-- PLEASE UPDATE THIS COTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
## Motivation

xdebug profiling is a useful tool, but the output files by default are saved compressed and in `/tmp` directory of each container which makes them hard to manage and view from the host machine. This change saves them uncompressed in the shared filesystem so that they are available to host tools like QCahcegrind

This change only affects settings when xdebug is _enabled_.

## Changes

- Update `xdebug` settings to be more developer friendly

## Testing

Turn on `xdebug` and do some profiling using your method of choice. Files should all end up in `<project_directory>/docroot/sites/default/files/xdebug-profile` and be uncompressed and ready to view.
