### PR TITLE
bump version lagoon.api

### DIFF
--- a/images/awx-ee/requirements.yml
+++ b/images/awx-ee/requirements.yml
@@ -7,7 +7,7 @@ collections:
   - kubernetes.core
   - name: lagoon.api
     source: https://github.com/salsadigitalauorg/lagoon_ansible_collection.git
-    version: 1.5.0
+    version: 2.0.0
     type: git
   - name: section.api
     source: https://github.com/salsadigitalauorg/section_ansible_collection.git


### PR DESCRIPTION
This update renames the token plugin to fetch_token.

Note: The [playbooks](https://github.com/dpc-sdp/sdp-ansible-playbooks/pull/181/files) in the linked PR must be merged before merging this PR.