### PR TITLE
Add shipshape binary

### DIFF
--- a/images/ci-builder/Dockerfile
+++ b/images/ci-builder/Dockerfile
@@ -5,6 +5,8 @@ ARG AHOY_VERSION=2.2.0
 ARG GOJQ_VERSION=0.12.17
 ARG HUB_VERSION=2.14.2
 ARG LAGOON_CLI_VERSION=0.31.2
+ARG SHIPSHAPE_VERSION=1.0.0-alpha.1.5.1
+ARG SDP_PLATFORM_RULES_VERSION=1.0.0
 
 # Ensure temp files dont end up in image.
 VOLUME /tmp
@@ -72,6 +74,12 @@ RUN curl -L https://github.com/itchyny/gojq/releases/download/v${GOJQ_VERSION}/g
 RUN curl -L -o "/usr/local/bin/ahoy" "https://github.com/ahoy-cli/ahoy/releases/download/v${AHOY_VERSION}/ahoy-bin-$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '-')" && \
     chmod +x /usr/local/bin/ahoy && \
     ahoy --version
+
+# Install shipshape and config.
+RUN curl -L -o /usr/local/bin/shipshape https://github.com/salsadigitalauorg/shipshape/releases/download/v${SHIPSHAPE_VERSION}/shipshape-$(uname -s)-$(uname -m) && \
+    chmod +x /usr/local/bin/shipshape && \
+    mkdir /bay && \
+    curl -L -o /bay/shipshape.yml https://raw.githubusercontent.com/dpc-sdp/sdp-platform-rules/v${SDP_PLATFORM_RULES_VERSION}/shipshape.yml
 
 # Install shellcheck.
 RUN apk add --no-cache shellcheck

--- a/images/ci-builder/Dockerfile
+++ b/images/ci-builder/Dockerfile
@@ -6,7 +6,6 @@ ARG GOJQ_VERSION=0.12.17
 ARG HUB_VERSION=2.14.2
 ARG LAGOON_CLI_VERSION=0.31.2
 ARG SHIPSHAPE_VERSION=1.0.0-alpha.1.5.1
-ARG SDP_PLATFORM_RULES_VERSION=1.0.0
 
 # Ensure temp files dont end up in image.
 VOLUME /tmp
@@ -75,11 +74,9 @@ RUN curl -L -o "/usr/local/bin/ahoy" "https://github.com/ahoy-cli/ahoy/releases/
     chmod +x /usr/local/bin/ahoy && \
     ahoy --version
 
-# Install shipshape and config.
+# Install shipshape.
 RUN curl -L -o /usr/local/bin/shipshape https://github.com/salsadigitalauorg/shipshape/releases/download/v${SHIPSHAPE_VERSION}/shipshape-$(uname -s)-$(uname -m) && \
-    chmod +x /usr/local/bin/shipshape && \
-    mkdir /bay && \
-    curl -L -o /bay/shipshape.yml https://raw.githubusercontent.com/dpc-sdp/sdp-platform-rules/v${SDP_PLATFORM_RULES_VERSION}/shipshape.yml
+    chmod +x /usr/local/bin/shipshape
 
 # Install shellcheck.
 RUN apk add --no-cache shellcheck

--- a/images/php/Dockerfile.cli
+++ b/images/php/Dockerfile.cli
@@ -10,7 +10,6 @@ ARG GOJQ_VERSION=0.12.17
 ARG DOCKERIZE_VERSION=v0.9.2
 ARG BAY_CLI_VERSION=v1.3.2
 ARG SHIPSHAPE_VERSION=1.0.0-alpha.1.5.1
-ARG SDP_PLATFORM_RULES_VERSION=1.0.0
 
 COPY --from=php-cli /usr/local/bin/phpdbg /usr/local/bin/
 ENV WEBROOT=docroot
@@ -39,10 +38,9 @@ RUN mkdir /bay
 COPY 01-bay.ini /usr/local/etc/php/conf.d/
 COPY bay-php-config.sh /bay
 
-# Install shipshape and config.
+# Install shipshape
 RUN curl -L -o /usr/local/bin/shipshape https://github.com/salsadigitalauorg/shipshape/releases/download/v${SHIPSHAPE_VERSION}/shipshape-$(uname -s)-$(uname -m) && \
-    chmod +x /usr/local/bin/shipshape && \
-    curl -L -o /bay/shipshape.yml https://raw.githubusercontent.com/dpc-sdp/sdp-platform-rules/v${SDP_PLATFORM_RULES_VERSION}/shipshape.yml
+    chmod +x /usr/local/bin/shipshape
 
 # Bay entrypoints.
 COPY entrypoints/ /lagoon/entrypoints

--- a/images/php/Dockerfile.cli
+++ b/images/php/Dockerfile.cli
@@ -9,6 +9,8 @@ RUN apk del postgresql-client
 ARG GOJQ_VERSION=0.12.17
 ARG DOCKERIZE_VERSION=v0.9.2
 ARG BAY_CLI_VERSION=v1.3.2
+ARG SHIPSHAPE_VERSION=1.0.0-alpha.1.5.1
+ARG SDP_PLATFORM_RULES_VERSION=1.0.0
 
 COPY --from=php-cli /usr/local/bin/phpdbg /usr/local/bin/
 ENV WEBROOT=docroot
@@ -36,6 +38,11 @@ RUN mkdir /bay
 
 COPY 01-bay.ini /usr/local/etc/php/conf.d/
 COPY bay-php-config.sh /bay
+
+# Install shipshape and config.
+RUN curl -L -o /usr/local/bin/shipshape https://github.com/salsadigitalauorg/shipshape/releases/download/v${SHIPSHAPE_VERSION}/shipshape-$(uname -s)-$(uname -m) && \
+    chmod +x /usr/local/bin/shipshape && \
+    curl -L -o /bay/shipshape.yml https://raw.githubusercontent.com/dpc-sdp/sdp-platform-rules/v${SDP_PLATFORM_RULES_VERSION}/shipshape.yml
 
 # Bay entrypoints.
 COPY entrypoints/ /lagoon/entrypoints


### PR DESCRIPTION
<!-- PLEASE UPDATE THIS COTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
## Motivation

Sites need to conform to platform requirements to ensure minimum supportability and operability with the SDP cluster. To ensure that we can effectively support these workloads, we need to be able to audit and verify that the running workloads meet our minimum standards via shipshape

## Changes

- Added shipshape binary to images:
  - Bay CLI image
  - Bay CI image

## Testing

- Bay CLI image: 
  - Build image with `docker build -f 'images/php/Dockerfile.cli' -t 'bay-cli:shipshape' 'images/php'  --platform linux/amd64`
  - Run with `docker run --rm --entrypoint bash bay-cli:shipshape -c "shipshape help" `
- Bay CI image: 
  - Build image with `docker build -f 'images/ci-builder/Dockerfile' -t 'bay-ci:shipshape' 'images/ci-builder' --platform linux/amd64`
  - Run with `docker run --rm --entrypoint bash bay-ci:shipshape -c "shipshape help"  `