### PR TITLE
Updated drush.yml to ensure --extra flag set on all drush sql commands

### DIFF
--- a/images/php/Dockerfile.cli
+++ b/images/php/Dockerfile.cli
@@ -49,6 +49,7 @@ COPY log-fatals.php /bay
 COPY db-build.sh /bay
 COPY db-dump-sanitized.sh /bay
 COPY mtk /bay/mtk
+COPY drush.yml /home/.drush/drush.yml
 
 # Provide a separate environment variable to configure the php cli memory limit.
 ENV PHP_CLI_MEMORY_LIMIT=1024M

--- a/images/php/drush.yml
+++ b/images/php/drush.yml
@@ -1,0 +1,26 @@
+options:
+  root: '/app/${env.WEBROOT}'
+  uri: '${env.LAGOON_ROUTE}'
+
+command:
+  sql:
+    cli:
+      options:
+        extra: '--disable-ssl'
+    query:
+      options:
+        extra: '--disable-ssl'
+    dump:
+      options:
+        extra: '--disable-ssl'
+        extra-dump: '--disable-ssl'
+    drop:
+      options:
+        extra: '--disable-ssl'
+    create:
+      options:
+        extra: '--disable-ssl'
+  site:
+    install:
+      options:
+        extra: '--disable-ssl'


### PR DESCRIPTION
## Motivation

For some reason drush sql commands have become flakey and require the `--extra='--disable-tls'` flag. Unfortunately drush 13.4 does not support this flag for `sql:drop` (among others) which is breaking builds.

## Changes
- Adds new version of drush.yml which adds the required flag to these options.

## Related PRs

- https://github.com/uselagoon/lagoon-images/pull/1264
- https://github.com/drush-ops/drush/pull/6249
- https://github.com/dpc-sdp/bay_platform_dependencies/pull/23
