### PR TITLE
Exclude data from router table in mtk drupal.conf

### DIFF
--- a/images/php/mtk/drupal.conf
+++ b/images/php/mtk/drupal.conf
@@ -60,5 +60,6 @@ nodata:
   - field_deleted_revision*
   - purge_queue
   - queue
+  - router
   - sessions
   - webform_*


### PR DESCRIPTION
## Motivation

I encountered an issue where the router table was not being exported properly by MTK. The data was malformed/truncated so PR environments were not working after a db sync.

Excluding data from the router table seemed to work around the issue without causing other problems.

## Changes

- Adds `router` table to excludes in mtk drupal.conf

## Testing

I have tested this by manually adjusting the drupal.conf file on a drupal project, then running a db sync with that environment as the source.

After a `drush cr` the target environment had rebuilt the data in that table, and was perfectly functional.
