### PR TITLE
Added support for multi-arch builds to ci-builder image

### DIFF
--- a/gh-actions-bake.hcl
+++ b/gh-actions-bake.hcl
@@ -9,7 +9,7 @@ target "ci-builder" {
   context       = "${CONTEXT}/ci-builder"
   dockerfile    = "Dockerfile"
 
-  platforms     = ["linux/amd64"]
+  platforms     = ["linux/amd64", "linux/arm64"]
 }
 target "elasticsearch" {
   inherits = ["docker-metadata-action"]

--- a/images/ci-builder/Dockerfile
+++ b/images/ci-builder/Dockerfile
@@ -37,10 +37,10 @@ RUN apk add --update --no-cache \
     python3-dev
 
 ## Install GitHub CLI tool.
-RUN curl -L "https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-linux-386-${HUB_VERSION}.tgz" -o /tmp/hub-linux-386-${HUB_VERSION}.tgz && \
-    tar -C /tmp -xzvf /tmp/hub-linux-386-${HUB_VERSION}.tgz && \
-    chmod +x /tmp/hub-linux-386-${HUB_VERSION}/bin/hub && \
-    mv /tmp/hub-linux-386-${HUB_VERSION}/bin/hub /usr/local/bin
+RUN curl -sL "https://github.com/mislav/hub/releases/download/v${HUB_VERSION}/hub-$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '-')-${HUB_VERSION}.tgz" -o /tmp/hub.tgz && \
+    tar -C /tmp -xzvf /tmp/hub.tgz && \
+    mv /tmp/hub-$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '-')-${HUB_VERSION}/bin/hub /usr/local/bin && \
+    chmod 755 /usr/local/bin
 
 ## Install required PHP extensions for Drupal and python packages.
 RUN apk add --no-cache \


### PR DESCRIPTION
## Motivation

I was unable to run the ci-builder image locally to debug an issue.

## Changes

- Fixed `hub` binary install to use target platform variable.
- Added linux/arm64 platform to bake file.
