### PR TITLE
Bumped versions of base image dependencies

### DIFF
--- a/images/awx-ee/execution-environment.yml
+++ b/images/awx-ee/execution-environment.yml
@@ -23,17 +23,17 @@ additional_build_steps:
     - LABEL org.opencontainers.image.title="SDP AWX Execution Environment image."
     - LABEL org.opencontainers.image.description="Provides an AWX execution environment image optimised for use with SDP. Built with ansible-builder."
     - LABEL org.opencontainers.image.source="https://github.com/dpc-sdp/bay/blob/6.x/images/awx-ee/"
-    - ARG LAGOON_CLI_VERSION=v0.31.2
-    - ARG NVM_INSTALL_VERSION=v0.39.7
-    - ARG NODE_VERSION=v20.9.0
+    - ARG LAGOON_CLI_VERSION=v0.32.0
+    - ARG NVM_INSTALL_VERSION=v0.40.3
+    - ARG NODE_VERSION=v20.19.3
     - ARG NVM_DIR="/runner/.nvm"
     - ARG PHP_VERSION="8.3"
     - ARG COMPOSER_VERSION="2.7.7"
     - ARG HUB_VERSION="2.14.2"
     - ARG GOJQ_VERSION="0.12.17"
-    - ARG HELM_VERSION="3.17.0"
-    - ARG YAMLFMT_VERSION="0.15.0"
-    - ARG KUBECTL_VERSION="1.32.0"
+    - ARG HELM_VERSION="3.18.3"
+    - ARG YAMLFMT_VERSION="0.17.2"
+    - ARG KUBECTL_VERSION="1.33.2"
 
   append_final:
     - | # Required dependencies.

--- a/images/ci-builder/Dockerfile
+++ b/images/ci-builder/Dockerfile
@@ -1,10 +1,10 @@
 FROM hashicorp/terraform:latest AS terraform
 FROM ghcr.io/dpc-sdp/sumocli:v0.11.1 AS sumocli
 FROM php:8.3-cli-alpine
-ARG AHOY_VERSION=2.2.0
+ARG AHOY_VERSION=2.4.0
 ARG GOJQ_VERSION=0.12.17
 ARG HUB_VERSION=2.14.2
-ARG LAGOON_CLI_VERSION=0.31.2
+ARG LAGOON_CLI_VERSION=0.32.0
 ARG SHIPSHAPE_VERSION=1.0.0-alpha.1.5.1
 
 # Ensure temp files dont end up in image.

--- a/images/mailpit/Dockerfile
+++ b/images/mailpit/Dockerfile
@@ -3,7 +3,7 @@
 #
 
 FROM alpine:latest
-ARG MAILPIT_VERSION=1.21.8
+ARG MAILPIT_VERSION=1.26.2
 
 # Install ca-certificates, required for the "release message" feature:
 RUN apk --no-cache add \

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -1,5 +1,5 @@
 FROM uselagoon/node-20:latest
-ARG BAY_CLI_VERSION=v1.3.2
+ARG BAY_CLI_VERSION=v1.4.1
 
 
 RUN apk --update add curl git findutils openssh-client && \

--- a/images/php/Dockerfile.cli
+++ b/images/php/Dockerfile.cli
@@ -1,6 +1,6 @@
 ARG PHP_VERSION=8.3
 FROM php:${PHP_VERSION}-cli-alpine AS php-cli
-FROM ghcr.io/skpr/mtk:v2.1.0 AS mtk
+FROM ghcr.io/skpr/mtk:v2.1.1 AS mtk
 FROM uselagoon/php-${PHP_VERSION}-cli-drupal:latest
 
 # Remove unnecessary packages that increase our attack surface area.
@@ -8,7 +8,7 @@ RUN apk del postgresql-client
 
 ARG GOJQ_VERSION=0.12.17
 ARG DOCKERIZE_VERSION=v0.9.2
-ARG BAY_CLI_VERSION=v1.3.2
+ARG BAY_CLI_VERSION=v1.4.1
 ARG SHIPSHAPE_VERSION=1.0.0-alpha.1.5.1
 
 COPY --from=php-cli /usr/local/bin/phpdbg /usr/local/bin/

--- a/images/php/Dockerfile.fpm
+++ b/images/php/Dockerfile.fpm
@@ -2,7 +2,7 @@ ARG PHP_VERSION=8.3
 FROM ghcr.io/dpc-sdp/bay/php-fpm-exporter:6.x AS php-fpm-exporter
 FROM uselagoon/php-${PHP_VERSION}-fpm:latest
 
-ARG BAY_CLI_VERSION=v1.3.2
+ARG BAY_CLI_VERSION=v1.4.1
 
 RUN mkdir /bay
 COPY 01-bay.ini /usr/local/etc/php/conf.d/


### PR DESCRIPTION
## Motivation

Bumps versions of base image dependencies.

## Changes

- lagoon-cli to 1.32.0
- nvm to 0.40.3
- node to 20.19.3
- helm to 3.18.3
- yamlfmt to 0.17.2
- kubectl to 1.33.2
- ahoy to 2.4.0
- mailpit to 1.26.2
- bay to 1.4.1
- mtk to 2.1.1

