### PR TITLE
Added aws-es-proxy base image

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -39,6 +39,7 @@ jobs:
             exclude:
               - images: mailpit
               - images: php-fpm-exporter
+              - images: aws-es-proxy
       - if: inputs.tag != '5.x'
         uses: druzsan/setup-matrix@v2
         with:

--- a/gh-actions-bake.hcl
+++ b/gh-actions-bake.hcl
@@ -93,6 +93,18 @@ target "php-fpm-exporter" {
     "org.opencontainers.image.source" = "https://github.com/dpc-sdp/bay/blob/6.x/images/bay-php-exporter/Dockerfile"
   }
 }
+
+target "aws-es-proxy" {
+  inherits = ["docker-metadata-action"]
+  context       = "${CONTEXT}/aws-es-proxy"
+  dockerfile    = "Dockerfile"
+
+  platforms     = ["linux/amd64", "linux/arm64"]
+
+  labels = {
+    "org.opencontainers.image.source" = "https://github.com/dpc-sdp/bay/blob/6.x/images/aws-es-proxy/Dockerfile"
+  }
+}
 target "ripple-static" {
   inherits = ["docker-metadata-action"]
   context       = "${CONTEXT}/ripple-static"

--- a/gh-actions-bake.hcl
+++ b/gh-actions-bake.hcl
@@ -101,9 +101,6 @@ target "aws-es-proxy" {
 
   platforms     = ["linux/amd64", "linux/arm64"]
 
-  labels = {
-    "org.opencontainers.image.source" = "https://github.com/dpc-sdp/bay/blob/6.x/images/aws-es-proxy/Dockerfile"
-  }
 }
 target "ripple-static" {
   inherits = ["docker-metadata-action"]

--- a/images/aws-es-proxy/Dockerfile
+++ b/images/aws-es-proxy/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:alpine AS build
+
+RUN apk add --no-cache git
+RUN git clone https://github.com/abutaha/aws-es-proxy.git /go/src/github.com/abutaha/aws-es-proxy
+WORKDIR /go/src/github.com/abutaha/aws-es-proxy
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o aws-es-proxy
+
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+WORKDIR /home/
+COPY --from=build /go/src/github.com/abutaha/aws-es-proxy/aws-es-proxy /usr/local/bin/
+COPY entrypoint.sh /entrypoint.sh
+RUN apk add --no-cache bash aws-cli
+
+ENV BAY_OPENSEARCH_ENDPOINT=
+ENV BAY_OPENSEARCH_ROLE=
+ENV BAY_OPENSEARCH_PROXY_TIMEOUT=60
+ENV BAY_OPENSEARCH_PROXY_FLAGS=
+ENV BAY_OPENSEARCH_PROXY_PORT=3000
+EXPOSE 3000
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/images/aws-es-proxy/README.md
+++ b/images/aws-es-proxy/README.md
@@ -1,0 +1,62 @@
+# Container Image - aws-es-proxy
+
+This container provides a secure proxy for requests to an AWS OpenSearch endpoint using the [aws-es-proxy](https://github.com/abutaha/aws-es-proxy) 
+tool. It is designed for seamless integration and automated IAM authentication, with robust defaults and runtime 
+configuration via environment variables.
+
+## Features
+
+- Secure proxying to AWS OpenSearch services.
+- Automatic validation of critical environment variables and AWS credentials.
+- Configurable timeouts, port, and proxy flags.
+- Flexible runtime configuration for debugging and verbosity.
+
+## Usage
+
+This image is typically intended for use as a proxy in your infrastructure.  
+You can use it in your Docker Compose stack with the following snippet:
+
+```yaml
+services: 
+  aws-es-proxy: 
+    image: ghcr.io/dpc-sdp/bay/aws-es-proxy:6.x 
+    environment: 
+      BAY_OPENSEARCH_ENDPOINT=https://your-opensearch-endpoint.amazonaws.com
+      BAY_OPENSEARCH_ROLE=arn:aws:iam::123456789012:role/your-role 
+    ports: 
+      - "3000:3000"
+```
+
+
+## Environment Variables
+
+| Name                      | Default Value | Description                                                                                   |
+|---------------------------|--------------|-----------------------------------------------------------------------------------------------|
+| `BAY_OPENSEARCH_ENDPOINT` | _(required)_ | The AWS OpenSearch domain endpoint to proxy requests to.                                       |
+| `BAY_OPENSEARCH_ROLE`     | _(required)_ | The AWS IAM role to assume for accessing the OpenSearch domain.                                |
+| `BAY_OPENSEARCH_PROXY_PORT`    | `3000`       | The port that the proxy listens on, inside the container.                                      |
+| `BAY_OPENSEARCH_PROXY_TIMEOUT` | `60`         | Timeout (in seconds) for incoming connections.                                                 |
+| `BAY_OPENSEARCH_PROXY_FLAGS`   | (empty)      | Extra flags passed to aws-es-proxy (e.g., `-debug -verbose`). See [aws-es-proxy docs](https://github.com/abutaha/aws-es-proxy?tab=readme-ov-file#usage-example) for options. |
+
+### Example: Enabling Debug and Verbose Logging
+
+```
+BAY_OPENSEARCH_PROXY_FLAGS=-debug -verbose
+```
+
+## Ports
+
+- **3000** (default, can be customized with `BAY_OPENSEARCH_PROXY_PORT`) – Proxy HTTP port
+
+## Entrypoint
+
+The container runs an entrypoint script that:
+
+1. Verifies mandatory environment variables and AWS credentials.
+2. Launches `aws-es-proxy` with your configuration.
+
+## AWS Credentials
+
+The container expects valid AWS credentials to be supplied via standard mechanisms (environment variables, mounted credentials files, or IAM roles if running in AWS ECS/EKS environments).
+
+For more advanced configuration, refer to the [aws-es-proxy documentation](https://github.com/abutaha/aws-es-proxy).

--- a/images/aws-es-proxy/entrypoint.sh
+++ b/images/aws-es-proxy/entrypoint.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# This script acts as a wrapper to securely proxy requests to an OpenSearch endpoint
+# using the aws-es-proxy tool. It performs the following steps:
+#   1. Validates that required environment variables (BAY_OPENSEARCH_ENDPOINT and BAY_OPENSEARCH_ROLE)
+#      are set and not empty.
+#   2. Verifies that valid AWS credentials are present. If credentials are invalid or missing, the
+#      script exits with an error.
+#   3. Starts the aws-es-proxy service.
+#
+# The following environment variables can be used to configure the behavior of this script:
+#   BAY_OPENSEARCH_ENDPOINT:      The AWS opensearch domain endpoint.
+#   BAY_OPENSEARCH_ROLE:          The AWS IAM role that should be assumed to access the opensearch
+#                                 domain.
+#   BAY_OPENSEARCH_PROXY_PORT:    Port that the aws-es-proxy should bind to.
+#   BAY_OPENSEARCH_PROXY_TIMEOUT: Timeout for incoming connections.
+#   BAY_OPENSEARCH_PROXY_FLAGS:   See [aws-es-proxy docs](https://github.com/abutaha/aws-es-proxy?tab=readme-ov-file#usage-example)
+#                                 for supported options here.
+#
+# If verbose or debug logs are required, set env var BAY_OPENSEARCH_PROXY_FLAGS="-debug -verbose"
+
+set -euo pipefail
+
+# Check if BAY_OPENSEARCH_ENDPOINT is unset or empty
+if [ -z "${BAY_OPENSEARCH_ENDPOINT:-}" ]; then
+  echo "Error: BAY_OPENSEARCH_ENDPOINT is not set or is empty" >&2
+  exit 1
+fi
+
+# Check if BAY_OPENSEARCH_ROLE is unset or empty
+if [ -z "${BAY_OPENSEARCH_ROLE:-}" ]; then
+  echo "Error: BAY_OPENSEARCH_ROLE= is not set or is empty" >&2
+  exit 1
+fi
+
+# Ensure AWS credentials exist and are valid
+AWS_PAGER="" aws sts get-caller-identity || (echo "Error: AWS credentials invalid" && exit 1)
+
+# Rest of your script here
+aws-es-proxy "${BAY_OPENSEARCH_PROXY_FLAGS:-}" \
+  -listen "0.0.0.0:${BAY_OPENSEARCH_PROXY_PORT:-3000}" \
+  -timeout "${BAY_OPENSEARCH_PROXY_TIMEOUT:-60}" \
+  -assume "${BAY_OPENSEARCH_ROLE}" \
+  -endpoint "${BAY_OPENSEARCH_ENDPOINT}"


### PR DESCRIPTION
## Motivation

- We are adding support for AWS Opensearch to the SDP tech stack. 
- We are intending to use IAM authentication rather than native opensearch accounts
- Because of this auth method, applications either need to implement AWS request signing natively, or connect via a proxy.

## Changes

Adds a new base image to the suite which runs the [aws-es-proxy](https://github.com/abutaha/aws-es-proxy).

