### PR TITLE
SDPPE-42: removed BAY_INGRESS_* environment variables and related logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,6 @@ Learn more from https://docs.lagoon.sh/
 
 ## Bay Features
 
-### Lock-down Ingress with Pre-Shared Key
-
-Using the nginx image, you can lock down access to your application with using a pre-shared key added at your CDN. 
-
-Set these environment variables in your nginx deployment:
-
-- `BAY_INGRESS_HEADER` defines the header which has the pre-shared key.
-- `BAY_INGRESS_PSK` is the token / PSK value.
-- `BAY_INGRESS_ENABLED` is a toggle for this feature, must be set to `"true"`.
-
-In your CDN configuration, set the header defined in `BAY_INGRESS_HEADER` with the token defined in `BAY_INGRESS_PSK`.
-
-- [Cloudfront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html)
-
-Once deployed, if the header is missing in the request nginx will return a `405 Not Allowed` HTTP response.
-
 ### Multiple architecture support
 Bay images are available in both amd64 and arm64 architectures.
 

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -2,16 +2,9 @@ FROM uselagoon/nginx-drupal:latest
 
 ENV WEBROOT=docroot
 ENV TZ=Australia/Melbourne
-ENV BAY_INGRESS_ENABLED=false
-ENV BAY_INGRESS_HEADER=""
-ENV BAY_INGRESS_PSK=""
+
 EXPOSE 8080
 EXPOSE 50000
-
-# Add ingress protection environment variable supprot to nginx.
-RUN sed -i '/env\ LAGOON_ENVIRONMENT_TYPE\;/a env BAY_INGRESS_ENABLED\;' /etc/nginx/nginx.conf \
-    && sed -i '/env\ LAGOON_ENVIRONMENT_TYPE\;/a env BAY_INGRESS_HEADER\;' /etc/nginx/nginx.conf \
-    && sed -i '/env\ LAGOON_ENVIRONMENT_TYPE\;/a env BAY_INGRESS_PSK\;' /etc/nginx/nginx.conf
 
 COPY helpers/ /etc/nginx/helpers/
 COPY prepend/ /etc/nginx/conf.d/drupal/

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -7,7 +7,6 @@ EXPOSE 8080
 EXPOSE 50000
 
 COPY helpers/ /etc/nginx/helpers/
-COPY prepend/ /etc/nginx/conf.d/drupal/
 COPY content /etc/nginx/conf.d/drupal/content
 
 # Add server append directives.

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -3,7 +3,6 @@
 Provides a nginx image optimised for the Bay container platform with the following features
 
 - Drupal compatible server block
-- Ingress protection with pre-shared keys
 - Optimised health checks for section.io
 
 ## Usage
@@ -29,9 +28,7 @@ services:
 
 | Name | Default Value | Description |
 |------|---------------|-------------|
-| `BAY_INGRESS_ENABLED` | `false` | Global toggle for ingress protection. Set to "true" to enable. |
-| `BAY_INGRESS_HEADER` | `<none>` | Name of header with PSK. |
-| `BAY_INGRESS_PSK` | `<none>` | Pre-shared key value |
+| _None_ | _N/A_ | _All previous ingress protection variables have been removed._ |
 
 ## Ports
 

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -26,9 +26,7 @@ services:
 
 ## Environment Variables
 
-| Name | Default Value | Description |
-|------|---------------|-------------|
-| _None_ | _N/A_ | _All previous ingress protection variables have been removed._ |
+None.
 
 ## Ports
 

--- a/images/nginx/prepend/100-ingress-protection.conf
+++ b/images/nginx/prepend/100-ingress-protection.conf
@@ -1,6 +1,0 @@
-# Bay Ingress Protection
-#
-# Allows nginx to reject requests if the corresponding PSK is not given by
-# the requesting client.
-
-# Intentionally left blank.

--- a/images/nginx/prepend/100-ingress-protection.conf
+++ b/images/nginx/prepend/100-ingress-protection.conf
@@ -3,25 +3,4 @@
 # Allows nginx to reject requests if the corresponding PSK is not given by
 # the requesting client.
 
-access_by_lua_block {
-  local ingress_protection_enabled = os.getenv('BAY_INGRESS_ENABLED')
-  local ingress_protection_psk = os.getenv('BAY_INGRESS_PSK')
-  local ingress_protection_key = os.getenv('BAY_INGRESS_HEADER')
-
-  if (ingress_protection_enabled == nil) or (ingress_protection_psk == nil) or (ingress_protection_key == nil) then
-    return
-  end
-
-  local sent_psk = ngx.req.get_headers()[ingress_protection_key]
-
-  if (ingress_protection_enabled == "true") and (ingress_protection_psk ~= sent_psk) then
-    local path = "/etc/nginx/conf.d/drupal/content/404.html"
-    local file = io.open(path, 'r')
-    local content = file:read "*all"
-    file:close()
-    ngx.header['Content-Type'] = 'text/html'
-    ngx.status = ngx.HTTP_NOT_FOUND
-    ngx.say(content)
-    ngx.exit(ngx.OK)
-  end
-}
+# Intentionally left blank.


### PR DESCRIPTION
<!-- PLEASE UPDATE THIS CONTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
## Motivation

BAY_INGRESS_* environment variables and related logic for ingress protection are deprecated and no longer required in the Bay project. Removing these references to keep bay project lean.

## Changes

- Removed BAY_INGRESS_* references from `README.md` and `images/nginx/README.md`.
- Removed BAY_INGRESS_* environment variables and related `sed` instructions from `images/nginx/Dockerfile`.
- Removed Lua logic from `images/nginx/prepend/100-ingress-protection.conf` that enforced BAY_INGRESS_* ingress protection.

## Testing
- Build docker image successfully using `docker build -t test-nginx -f images/nginx/Dockerfile .`
- Confirmed container starts without errors using `docker run --rm -it test-nginx`.
- Validated that references to BAY_INGRESS_* no longer exist in any of the files inside this repository

