### PR TITLE
[SD-1147] Fixing one environment colour indicator for all

### DIFF
--- a/images/php/settings.php
+++ b/images/php/settings.php
@@ -411,7 +411,5 @@ if (file_exists($deployment_metadata_path)) {
     $label = ($tag !== 'No tag found') ? "$msg - $authorName ($short_sha)" : $short_sha;
 
     $config['environment_indicator.indicator']['name'] = "Deployed: $label";
-    $config['environment_indicator.indicator']['bg_color'] = '#fff176';
-    $config['environment_indicator.indicator']['fg_color'] = '#000000';
   }
 }


### PR DESCRIPTION
<!-- PLEASE UPDATE THIS COTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
###JIRA
https://digital-vic.atlassian.net/browse/SD-1147
## Motivation
The colour indicator should be different from environment to Environment. By adding the colour indicator overrides the the settings php from project and ends up showing same colour for development and production environment. The colour should still be set in different environment type from the settings.php in the project level.

## Changes
1. Removed the colour indicator

###Note
Looks like the release task to remove the indicator from the project level settings php didn't work [here](https://github.com/dpc-sdp/sdp-ansible-upgrade/pull/202/files#diff-87409368591914579e84b7aafe6f6ba81e431401bdd79fc0ccf4695f4ea5faa8R8), so it is safe to just remove it from here and after deployment, it should pick the colours from the project level settings php

## Testing
