### PR TITLE
[SDPPE-126] Added opensearch image

### DIFF
--- a/gh-actions-bake.hcl
+++ b/gh-actions-bake.hcl
@@ -11,6 +11,13 @@ target "ci-builder" {
 
   platforms     = ["linux/amd64", "linux/arm64"]
 }
+target "opensearch" {
+  inherits = ["docker-metadata-action"]
+  context       = "${CONTEXT}/opensearch"
+  dockerfile    = "Dockerfile"
+
+  platforms     = ["linux/amd64", "linux/arm64"]
+}
 target "elasticsearch" {
   inherits = ["docker-metadata-action"]
   context       = "${CONTEXT}/elasticsearch"

--- a/gh-actions-bake.hcl
+++ b/gh-actions-bake.hcl
@@ -20,7 +20,7 @@ target "opensearch" {
 }
 target "elasticsearch" {
   inherits = ["docker-metadata-action"]
-  context       = "${CONTEXT}/elasticsearch"
+  context       = "${CONTEXT}/opensearch"
   dockerfile    = "Dockerfile"
 
   platforms     = ["linux/amd64", "linux/arm64"]

--- a/images/elasticsearch/Dockerfile
+++ b/images/elasticsearch/Dockerfile
@@ -1,6 +1,0 @@
-FROM elasticsearch:8.16.1
-
-ENV ES_PATH=/usr/share/elasticsearch
-
-RUN $ES_PATH/bin/elasticsearch-plugin install analysis-kuromoji \
-    && $ES_PATH/bin/elasticsearch-plugin install analysis-icu

--- a/images/opensearch/Dockerfile
+++ b/images/opensearch/Dockerfile
@@ -5,3 +5,5 @@ RUN for plugin in \
   analysis-icu; do \
     /usr/share/opensearch/bin/opensearch-plugin install $plugin; \
   done
+
+COPY opensearch.yml /usr/share/opensearch/config

--- a/images/opensearch/Dockerfile
+++ b/images/opensearch/Dockerfile
@@ -1,0 +1,7 @@
+FROM uselagoon/opensearch-2:latest
+
+RUN for plugin in \
+  analysis-kuromoji \
+  analysis-icu; do \
+    /usr/share/opensearch/bin/opensearch-plugin install $plugin; \
+  done

--- a/images/opensearch/opensearch.yml
+++ b/images/opensearch/opensearch.yml
@@ -1,0 +1,7 @@
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+
+discovery.type: single-node
+plugins.security.disabled: true
+
+path.repo: ["/usr/share/elasticsearch/data/snapshots"]


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/SDPPE-126

## Motivation

For completeness, local dev and CI should be using opensearch rather than elasticsearch.

## Changes

- Adds an `opensearch` image based on what is in the current bay `elasticsearch` image.
- Removes the `elasticsearch` Dockerfile, and instead mirrors the new opensearch image to elasticsearch in the registry.

