### PR TITLE
SDPPE-123: Enable and align workflows for 7.x branch

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -2,9 +2,13 @@ name: build-deploy-bay-images
 run-name: Build and deploy Bay images
 on:
   pull_request:
-    types: [closed, opened, synchronize]
+    types: 
+      - closed
+      - opened
+      - synchronize
   issue_comment:
-    types: [created]
+    types:
+      - created
   schedule:
     - cron: '23 20 * * 0'
   workflow_dispatch:
@@ -56,13 +60,14 @@ jobs:
           tags: |
             # PR images (not merged): pr-<num>
             type=ref,event=pr,enable=${{ github.event.pull_request.merged == false }}
-            # Tag with the PR base branch name on merge (e.g., 6.x or 7.x)
+            # Tag with the PR base branch name on merge
             type=raw,value=${{ github.event.pull_request.base.ref }},enable=${{ github.event.pull_request.merged == true }}
-            # Manual/scheduled runs tag by branch ref (when the run targets 6.x or 7.x)
+            # Manual/scheduled runs tag by branch ref (for whichever release branch the run targets)
             type=ref,event=branch,enable=${{ contains(fromJson('["schedule", "workflow_dispatch"]'), github.event_name) }}
             # Comment-triggered builds: pr-<num>
             type=raw,event=default,value=pr-${{ github.event.issue.number }},enable=${{ github.event.issue.pull_request != null }}
-            # --- explicit safety rails for branch tags ---
+            # Supported release branches
+            type=raw,value=5.x,enable=${{ github.ref == 'refs/heads/5.x' || github.event.pull_request.base.ref == '5.x' }}
             type=raw,value=6.x,enable=${{ github.ref == 'refs/heads/6.x' || github.event.pull_request.base.ref == '6.x' }}
             type=raw,value=7.x,enable=${{ github.ref == 'refs/heads/7.x' || github.event.pull_request.base.ref == '7.x' }}
             # Always add an immutable sha tag

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -2,13 +2,9 @@ name: build-deploy-bay-images
 run-name: Build and deploy Bay images
 on:
   pull_request:
-    types:
-      - closed
-      - opened
-      - synchronize
+    types: [closed, opened, synchronize]
   issue_comment:
-    types:
-      - created
+    types: [created]
   schedule:
     - cron: '23 20 * * 0'
   workflow_dispatch:
@@ -17,11 +13,11 @@ env:
   REGISTRY: ghcr.io
 jobs:
   buildx:
-    if: |-
+    if: |
       github.event.pull_request.merged == true || 
       contains(fromJson('["schedule", "workflow_dispatch"]'), github.event_name) || 
-      github.event_name == 'pull_request' && startsWith(github.head_ref,'build/') ||
-      ( github.event.issue.pull_request && contains(github.event.comment.body, '/build') )
+      (github.event_name == 'pull_request' && startsWith(github.head_ref,'build/')) ||
+      (github.event.issue.pull_request && contains(github.event.comment.body, '/build'))
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,19 +29,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - uses: actions/checkout@v3
-        if: |-
+      - uses: actions/checkout@v4
+        if: |
           github.event.pull_request.merged == true || 
           contains(fromJson('["schedule", "workflow_dispatch"]'), github.event_name) || 
-          github.event_name == 'pull_request' && startsWith(github.head_ref,'build/')
+          (github.event_name == 'pull_request' && startsWith(github.head_ref,'build/'))
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ( github.event.issue.pull_request && contains(github.event.comment.body, '/build') )
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
 
       - name: Login to registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v2.2.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.REGISTRY_USER }}
@@ -53,15 +49,24 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v4.6.0
+        uses: docker/metadata-action@v5
         with:
           images: |
             ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.images }}
           tags: |
+            # PR images (not merged): pr-<num>
             type=ref,event=pr,enable=${{ github.event.pull_request.merged == false }}
+            # Tag with the PR base branch name on merge (e.g., 6.x or 7.x)
             type=raw,value=${{ github.event.pull_request.base.ref }},enable=${{ github.event.pull_request.merged == true }}
+            # Manual/scheduled runs tag by branch ref (when the run targets 6.x or 7.x)
             type=ref,event=branch,enable=${{ contains(fromJson('["schedule", "workflow_dispatch"]'), github.event_name) }}
+            # Comment-triggered builds: pr-<num>
             type=raw,event=default,value=pr-${{ github.event.issue.number }},enable=${{ github.event.issue.pull_request != null }}
+            # --- explicit safety rails for branch tags ---
+            type=raw,value=6.x,enable=${{ github.ref == 'refs/heads/6.x' || github.event.pull_request.base.ref == '6.x' }}
+            type=raw,value=7.x,enable=${{ github.ref == 'refs/heads/7.x' || github.event.pull_request.base.ref == '7.x' }}
+            # Always add an immutable sha tag
+            type=raw,value=sha-${{ github.sha }}
           labels: |
             maintainer=Digital Victoria
             repository=${{ github.repositoryUrl }}
@@ -88,7 +93,7 @@ jobs:
           retention-days: 1
 
       - name: Build and push the images
-        uses: docker/bake-action@v3.1.0
+        uses: docker/bake-action@v5
         with:
           push: true
           files: |

--- a/.github/workflows/vulnerability-scan-schedule-7x.yml
+++ b/.github/workflows/vulnerability-scan-schedule-7x.yml
@@ -1,0 +1,27 @@
+name: vulnerability-scan-schedule-7.x
+run-name: Scheduled CVE vulnerability scan of 7.x published images.
+
+env:
+  REGISTRY: ghcr.io
+
+on:
+  schedule:
+    - cron: '2 22 * * 3'  # same schedule as 6.x;
+  workflow_dispatch:
+    inputs:
+      summary:
+        description: 'Summary of the scheduled scan.'
+        required: false
+        default: 'Trivy CVE scan of 7.x published images.'
+      tag:
+        description: 'Tag to scan.'
+        required: false
+        default: '7.x'
+
+jobs:
+  vulnerability-scan-schedule:
+    name: Scan for vulnerabilities on 7.x images
+    uses: "dpc-sdp/bay/.github/workflows/vulnerability-scan.yml@7.x"
+    with:
+      tag: "7.x"
+      summary: "Trivy CVE scan of 7.x published images."

--- a/.github/workflows/vulnerability-scan-schedule-7x.yml
+++ b/.github/workflows/vulnerability-scan-schedule-7x.yml
@@ -6,7 +6,7 @@ env:
 
 on:
   schedule:
-    - cron: '2 22 * * 3'  # same schedule as 6.x;
+    - cron: '12 22 * * 3'
   workflow_dispatch:
     inputs:
       summary:


### PR DESCRIPTION
<!-- PLEASE UPDATE THIS COTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
## Motivation

The 7.x branch required build and vulnerability scan workflows to be aligned with our n-1, n, and n+1 support strategy. 

## Changes

- Enabled build workflow for 7.x branch.
- Added vulnerability-scan-schedule-7x.yml to run after 6.x scan.
- Updated tagging logic to explicitly include 5.x, 6.x, and 7.x branch tags where required.

## Testing

- Tested running a workflow for 7.x branch, expected tag were created
- e.g. https://github.com/dpc-sdp/bay/actions/runs/16957823591/job/48063435021#step:7:698

##[debug]Node Action run completed with exit code 0
##[debug]DOCKER_METADATA_OUTPUT_VERSION='7.x'
##[debug]DOCKER_METADATA_OUTPUT_TAGS='ghcr.io/dpc-sdp/bay/elasticsearch:7.x
##[debug]ghcr.io/dpc-sdp/bay/elasticsearch:sha-b5d5ecd3ec1adf5fa498f899b10531f8af7793dc'
##[debug]DOCKER_METADATA_OUTPUT_LABELS='maintainer=Digital Victoria
