### PR TITLE
Update lagoon.api collection version to 2.2.0

### DIFF
--- a/images/awx-ee/requirements.yml
+++ b/images/awx-ee/requirements.yml
@@ -8,7 +8,7 @@ collections:
   - kubernetes.core
   - name: lagoon.api
     source: https://github.com/salsadigitalauorg/lagoon_ansible_collection.git
-    version: 2.1.0
+    version: 2.2.0
     type: git
   - name: section.api
     source: https://github.com/salsadigitalauorg/section_ansible_collection.git


### PR DESCRIPTION
<!-- PLEASE UPDATE THIS COTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
## Motivation

gql v4 was released yesterday which has caused all lagoon inventory synchronisation to fail. This is due to a lack of dependency pinning in the lagoon_ansible_collection. Relevant PR here https://github.com/salsadigitalauorg/lagoon_ansible_collection/pull/110.

lagoon_ansible_collection has now been updated to pin the gql library to an appropriate version.

## Changes

- Updated lagoon_ansible_collection to 2.2.0

## Testing

- Ensure image is built with gql library version < 4 (likely 3.5.3)
- AWX lagoon inventory synchronisation jobs will complete successfully.
