### PR TITLE
[SD-1322] Prevent scheduled_transition crashes caused by missing node…

### DIFF
--- a/images/php/mtk/drupal.conf
+++ b/images/php/mtk/drupal.conf
@@ -63,3 +63,4 @@ nodata:
   - router
   - sessions
   - webform_*
+  - scheduled_transition*


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-1322

### Issues
During drush cron execution, the scheduled_transition module may crash if there are incomplete or missing node revisions in the database. 

<img width="2920" height="1022" alt="image" src="https://github.com/user-attachments/assets/b8c042c9-0362-4ece-9306-4d77296484d6" />

### Fix
Don't dump all of the scheduled_transition entities.
