### PR TITLE
Removed redundant opensearch config file.

### DIFF
--- a/images/opensearch/Dockerfile
+++ b/images/opensearch/Dockerfile
@@ -5,5 +5,3 @@ RUN for plugin in \
   analysis-icu; do \
     /usr/share/opensearch/bin/opensearch-plugin install $plugin; \
   done
-
-COPY opensearch.yml /usr/share/opensearch/config

--- a/images/opensearch/opensearch.yml
+++ b/images/opensearch/opensearch.yml
@@ -1,7 +1,0 @@
-cluster.name: "docker-cluster"
-network.host: 0.0.0.0
-
-discovery.type: single-node
-plugins.security.disabled: true
-
-path.repo: ["/usr/share/elasticsearch/data/snapshots"]


### PR DESCRIPTION
## Motivation

The file duplicates the config that comes in the upstream image, and using our own was causing some permissions issues on container boot. This issue was preventing testing of opensearch in a local stack.

## Changes

- Removes custom opensearch.yml file.
