### PR TITLE
Rewrites BAY_OPENSEARCH_ENDPOINT if using a custom domain

### DIFF
--- a/images/aws-es-proxy/Dockerfile
+++ b/images/aws-es-proxy/Dockerfile
@@ -8,12 +8,17 @@ RUN go get -u && go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -o aws-es-proxy
 
 FROM alpine:latest
+ARG URI_REWRITER_VERSION=v0.0.1-alpha1
 
 RUN apk --no-cache add ca-certificates
 WORKDIR /home/
 COPY --from=build /go/src/github.com/abutaha/aws-es-proxy/aws-es-proxy /usr/local/bin/
 COPY entrypoint.sh /entrypoint.sh
 RUN apk add --no-cache bash aws-cli
+
+RUN wget "https://github.com/dpc-sdp/uri-rewriter/releases/download/${URI_REWRITER_VERSION}/uri-rewriter_$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '_').tar.gz" -O /tmp/uri-rewriter.tgz && \
+    cd /bin && \
+    tar -vxxzf /tmp/uri-rewriter.tgz
 
 ENV BAY_OPENSEARCH_ENDPOINT=
 ENV BAY_OPENSEARCH_ROLE=

--- a/images/aws-es-proxy/Dockerfile
+++ b/images/aws-es-proxy/Dockerfile
@@ -18,7 +18,8 @@ RUN apk add --no-cache bash aws-cli
 
 RUN wget "https://github.com/dpc-sdp/uri-rewriter/releases/download/${URI_REWRITER_VERSION}/uri-rewriter_$(echo ${TARGETPLATFORM:-linux/amd64} | tr '/' '_').tar.gz" -O /tmp/uri-rewriter.tgz && \
     cd /bin && \
-    tar -vxxzf /tmp/uri-rewriter.tgz
+    tar -vxxzf /tmp/uri-rewriter.tgz && \
+    rm -rf /tmp/uri-rewriter.tgz
 
 ENV BAY_OPENSEARCH_ENDPOINT=
 ENV BAY_OPENSEARCH_ROLE=

--- a/images/aws-es-proxy/entrypoint.sh
+++ b/images/aws-es-proxy/entrypoint.sh
@@ -4,9 +4,11 @@
 # using the aws-es-proxy tool. It performs the following steps:
 #   1. Validates that required environment variables (BAY_OPENSEARCH_ENDPOINT and BAY_OPENSEARCH_ROLE)
 #      are set and not empty.
-#   2. Verifies that valid AWS credentials are present. If credentials are invalid or missing, the
+#   2. If BAY_OPENSEARCH_ENDPOINT is a custom domain, rewrites to the AWS
+#      endpoint to ensure sigv4 request signing works.
+#   3. Verifies that valid AWS credentials are present. If credentials are invalid or missing, the
 #      script exits with an error.
-#   3. Starts the aws-es-proxy service.
+#   4. Starts the aws-es-proxy service.
 #
 # The following environment variables can be used to configure the behavior of this script:
 #   BAY_OPENSEARCH_ENDPOINT:      The AWS opensearch domain endpoint.
@@ -43,6 +45,11 @@ if [ "${BAY_OPENSEARCH_PROXY_VERBOSE:-false}" = "true" ]; then
   AWS_ES_PROXY_VERBOSE_FLAG="-verbose"
 fi
 
+if ! [[ "$BAY_OPENSEARCH_ENDPOINT" == *amazonaws.com* ]]; then
+  echo "endpoint appears to be a custom domain - adjusting to aws endpoint"
+  BAY_OPENSEARCH_ENDPOINT=$(uri-rewriter hostname-cname "${BAY_OPENSEARCH_ENDPOINT}")
+  echo " - updated endpoint to ${BAY_OPENSEARCH_ENDPOINT}"
+fi
 
 # Ensure AWS credentials exist and are valid
 AWS_PAGER="" aws sts get-caller-identity || (echo "Error: AWS credentials invalid" && exit 1)


### PR DESCRIPTION
## Motivation

Using custom hostnames on a AWS opensearch domain causes sigv4 request signing to fail. This affects us as we want to use subdomains of `sdp.vic.gov.au` to make managing the opensearch infrastructure easier.

## Changes

- Adds the `uri-rewrite` binary to the `aws-es-proxy` image - https://github.com/dpc-sdp/uri-rewriter
- Adjusts aws-es-proxy entrypoint script to rewrite the BAY_OPENSEARCH_ENDPOINT value if it does not appear to be an AWS endpoint.

