### PR TITLE
[SDPPE-168] Set PHP db conn default collation.

### DIFF
--- a/images/mariadb/Dockerfile
+++ b/images/mariadb/Dockerfile
@@ -1,7 +1,5 @@
-FROM uselagoon/mariadb-drupal:latest
+FROM uselagoon/mariadb-10.11-drupal:latest
 
-ENV MARIADB_CHARSET=latin1
-ENV MARIADB_COLLATION=latin1_swedish_ci
 ENV MARIADB_INNODB_LOG_FILE_SIZE=256M
 ENV MARIADB_MAX_ALLOWED_PACKET=512M
 

--- a/images/php/settings.php
+++ b/images/php/settings.php
@@ -35,6 +35,7 @@ $connection_info = [
   'host' => getenv('MARIADB_HOST') ?: 'mariadb',
   'port' => 3306,
   'prefix' => '',
+  'collation' => 'utf8mb4_general_ci',
 ];
 
 $databases['default']['default'] = $connection_info;


### PR DESCRIPTION
<!-- PLEASE UPDATE THIS COTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
## Motivation

Preparation for mysql 8 upgrade

## Changes

Added mysql 5.7 compatible collation and avoids mix of collations.