### PR TITLE
[SD-1637] Override ChainedFast cache bins to use Redis directly

### DIFF
--- a/images/php/settings.php
+++ b/images/php/settings.php
@@ -122,9 +122,9 @@ if (getenv('ENABLE_REDIS') && !\Drupal\Core\Installer\InstallerKernel::installat
   $settings['redis.connection']['read_timeout'] = $redis_timeout;
   $settings['redis.connection']['timeout'] = $redis_timeout;
   $settings['cache']['default'] = 'cache.backend.redis';
-  $settings['cache']['bins']['bootstrap'] = 'cache.backend.chainedfast';
-  $settings['cache']['bins']['discovery'] = 'cache.backend.chainedfast';
-  $settings['cache']['bins']['config'] = 'cache.backend.chainedfast';
+  $settings['cache']['bins']['bootstrap'] = 'cache.backend.redis';
+  $settings['cache']['bins']['discovery'] = 'cache.backend.redis';
+  $settings['cache']['bins']['config'] = 'cache.backend.redis';
 
   $settings['cache_prefix']['default'] = getenv('REDIS_CACHE_PREFIX') ?: getenv('LAGOON_PROJECT') . '_' . getenv('LAGOON_GIT_SAFE_BRANCH');
 


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-1637

### Changes and reasons
- override Bay's default `cache.backend.chainedfast` setting for bootstrap, config, and discovery bins to `cache.backend.redis`
- eliminates APCu memory pressure (80-90% utilisation on 32MB) caused by ChainedFastBackend's invalidation-refill cycle(detailed in the [ticket](https://digital-vic.atlassian.net/browse/SD-1637).)
- APCu remains in use for `drupal.file_cache` (yaml/annotation parsing) and `drupal.class_loader`(composer related.)

### some relevant references

  - [APCu lock contention under ChainedFast](https://github.com/krakjoe/apcu/issues/333)
  - [ChainedFastBackend full-bin invalidation](https://www.drupal.org/project/drupal/issues/2611400)
  - [Redis module configuration docs](https://project.pages.drupalcode.org/redis/#common-configuration)

### After the change
![CleanShot 2026-03-11 at 11 00 18](https://github.com/user-attachments/assets/533c2ac1-c650-427e-8906-99e37073b39b)
![CleanShot 2026-03-11 at 11 00 34](https://github.com/user-attachments/assets/ffda6233-6645-48b7-b48c-4dad6ae4969f)
