### PR TITLE
[SD-1670] Fix Paragraph data loss caused by unsafe MTK revision cleanup.

### DIFF
--- a/images/php/mtk/drupal.conf
+++ b/images/php/mtk/drupal.conf
@@ -13,15 +13,6 @@ where:
   admin_audit_trail: |-
     created >= FROM_UNIXTIME(DATE_SUB(NOW(), INTERVAL 7 DAY))
   # Exclude unpublished revision data that takes up too much space.
-  # Paragraphs
-  paragraphs_item_revision: |-
-    revision_id IN (SELECT revision_id FROM paragraphs_item)
-  paragraphs_item_revision_field_data: |-
-    revision_id IN (SELECT revision_id FROM paragraphs_item)
-  paragraph_revision__*: |-
-    revision_id IN (SELECT revision_id FROM paragraphs_item)
-  paragraph_r__*: |-
-    revision_id IN (SELECT revision_id FROM paragraphs_item)
   # Blocks
   block_content_revision: |-
     revision_id IN (SELECT revision_id FROM block_content)


### PR DESCRIPTION


<!-- PLEASE UPDATE THIS COTENT. NO PR WILL BE REVIEWED WITHOUT A PROPER DESCRIPTION. -->
## JIRA
https://digital-vic.atlassian.net/browse/SD-1670

## Motivation
The current MTK cleanup rules for Paragraph revision tables were incorrectly removing revision records using the condition:

`revision_id IN (SELECT revision_id FROM paragraphs_item)`

This logic assumes that only the latest (default) Paragraph revision is required. However, in Drupal, nodes reference Paragraphs using target_revision_id, meaning published nodes can depend on non-default (older) paragraph revisions.

As a result, the cleanup process was deleting revision data that is still actively referenced by nodes, causing Paragraph components to disappear from published content.

## Changes

Removed unsafe MTK cleanup rules targeting:

`paragraphs_item_revision`

`paragraphs_item_revision_field_data`

`paragraph_revision__*`

`paragraph_r__*`

## Paragraph Revision Bloat
To confirm why our previous MTK where clauses were "hollowing out" pages, I performed a database trace on a standard Landing Page.

The Test: Edit the Page Title only. Do not touch the Paragraph components.

1. Initial State (Node v1922)
The Node is currently at revision 1922, and its attached Paragraph is at revision 7069.
### Check Node Revision
`$ drush sql-query "SELECT nid, vid, title FROM node_field_data WHERE nid = 1171;"
1171 | 1922 | test paragraph version`

### Check Paragraph Revision
`$ drush sql-query "SELECT field_landing_page_component_target_id AS id, field_landing_page_component_target_revision_id AS rev FROM node_revision__field_landing_page_component WHERE entity_id = 1171;"
4347 | 7069`

2. After Editing Only the Page Title (Node v1923)
Even though the Paragraph content was not changed, saving the Node triggered a new revision for the Paragraph automatically.
### Check Node Revision (Increments to 1923)
`$ drush sql-query "SELECT nid, vid, title FROM node_field_data WHERE nid = 1171;"
1171 | 1923 | test paragraph version we`

### Check Paragraph Revision (A new rev 7070 is created!)
`$ drush sql-query "SELECT field_landing_page_component_target_id AS id, field_landing_page_component_target_revision_id AS rev FROM node_revision__field_landing_page_component WHERE entity_id = 1171;"
4347 | 7069
4347 | 7070  <-- NEW REVISION`

## Testing

Build image with `docker build -t test -f images/foo/Dockerfile` and run with `docker run --rm -it test`
