### PR TITLE
[SDPPE-331] Update all dependencies

### DIFF
--- a/images/awx-ee/execution-environment.yml
+++ b/images/awx-ee/execution-environment.yml
@@ -23,16 +23,16 @@ additional_build_steps:
     - LABEL org.opencontainers.image.title="SDP AWX Execution Environment image."
     - LABEL org.opencontainers.image.description="Provides an AWX execution environment image optimised for use with SDP. Built with ansible-builder."
     - LABEL org.opencontainers.image.source="https://github.com/dpc-sdp/bay/blob/6.x/images/awx-ee/"
-    - ARG LAGOON_CLI_VERSION=v0.32.0
-    - ARG NVM_INSTALL_VERSION=v0.40.3
-    - ARG NODE_VERSION=v20.19.3
+    - ARG LAGOON_CLI_VERSION=v0.33.0
+    - ARG NVM_INSTALL_VERSION=v0.40.4
+    - ARG NODE_VERSION=v20.20.2
     - ARG NVM_DIR="/runner/.nvm"
     - ARG PHP_VERSION="8.3"
-    - ARG COMPOSER_VERSION="2.7.7"
-    - ARG GOJQ_VERSION="0.12.17"
-    - ARG HELM_VERSION="3.18.3"
-    - ARG YAMLFMT_VERSION="0.17.2"
-    - ARG KUBECTL_VERSION="1.33.2"
+    - ARG COMPOSER_VERSION="2.10.1"
+    - ARG GOJQ_VERSION="0.12.19"
+    - ARG HELM_VERSION="3.21.0"
+    - ARG YAMLFMT_VERSION="0.21.0"
+    - ARG KUBECTL_VERSION="1.36.1"
 
   append_final:
     - | # Required dependencies.
@@ -70,7 +70,12 @@ additional_build_steps:
     - RUN curl -sS "https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar" --output composer.phar
     - RUN chmod +x composer.phar
     - RUN mv composer.phar /usr/local/bin/composer
-    - RUN composer global require szeidler/composer-patches-cli:^1.0
+    - |
+      RUN set -eux; \
+          composer global config --no-plugins allow-plugins.cweagans/composer-configurable-plugin true; \
+          composer global config --no-plugins allow-plugins.cweagans/composer-patches true; \
+          composer global config --no-plugins allow-plugins.szeidler/composer-patches-cli true; \
+          composer global require -n szeidler/composer-patches-cli:^1.0
     - RUN curl -L "https://github.com/itchyny/gojq/releases/download/v${GOJQ_VERSION}/gojq_v${GOJQ_VERSION}_linux_amd64.tar.gz" --output /tmp/gojq_v${GOJQ_VERSION}_linux_amd64.tar.gz
     - RUN tar -C /tmp -xvf /tmp/gojq_v${GOJQ_VERSION}_linux_amd64.tar.gz
     - RUN chmod +x /tmp/gojq_v${GOJQ_VERSION}_linux_amd64/gojq

--- a/images/ci-builder/Dockerfile
+++ b/images/ci-builder/Dockerfile
@@ -1,10 +1,10 @@
 FROM hashicorp/terraform:latest AS terraform
 FROM ghcr.io/dpc-sdp/sumocli:v0.11.2 AS sumocli
 FROM php:8.3-cli-alpine
-ARG AHOY_VERSION=2.4.0
-ARG GOJQ_VERSION=0.12.17
-ARG LAGOON_CLI_VERSION=0.32.0
-ARG SHIPSHAPE_VERSION=1.0.0-alpha.1.5.1
+ARG AHOY_VERSION=2.5.0
+ARG GOJQ_VERSION=0.12.19
+ARG LAGOON_CLI_VERSION=0.33.0
+ARG SHIPSHAPE_VERSION=1.0.0-alpha.1.5.2
 
 # Ensure temp files dont end up in image.
 VOLUME /tmp

--- a/images/mailpit/Dockerfile
+++ b/images/mailpit/Dockerfile
@@ -3,7 +3,7 @@
 #
 
 FROM alpine:latest
-ARG MAILPIT_VERSION=1.26.2
+ARG MAILPIT_VERSION=1.30.1
 
 # Install ca-certificates, required for the "release message" feature:
 RUN apk --no-cache add \

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -1,5 +1,5 @@
 FROM uselagoon/node-20:latest
-ARG BAY_CLI_VERSION=v1.4.1
+ARG BAY_CLI_VERSION=v1.4.11
 
 
 RUN apk --update add curl git findutils openssh-client && \
@@ -15,5 +15,5 @@ RUN mv /tmp/bay /bin/bay
 COPY entrypoints/ /lagoon/entrypoints
 
 # Prevents installation of large binaries only used for development.
-ENV CYPRESS_INSTALL_BINARY 0
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD 1
+ENV CYPRESS_INSTALL_BINARY=0
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1

--- a/images/php/Dockerfile.cli
+++ b/images/php/Dockerfile.cli
@@ -1,15 +1,15 @@
 ARG PHP_VERSION=8.3
 FROM php:${PHP_VERSION}-cli-alpine AS php-cli
-FROM ghcr.io/skpr/mtk:v2.1.1 AS mtk
+FROM ghcr.io/skpr/mtk:v2.3.3 AS mtk
 FROM uselagoon/php-${PHP_VERSION}-cli-drupal:latest
 
 # Remove unnecessary packages that increase our attack surface area.
 RUN apk del postgresql-client
 
-ARG GOJQ_VERSION=0.12.17
-ARG DOCKERIZE_VERSION=v0.9.2
-ARG BAY_CLI_VERSION=v1.4.1
-ARG SHIPSHAPE_VERSION=1.0.0-alpha.1.5.1
+ARG GOJQ_VERSION=0.12.19
+ARG DOCKERIZE_VERSION=v0.12.0
+ARG BAY_CLI_VERSION=v1.4.11
+ARG SHIPSHAPE_VERSION=1.0.0-alpha.1.5.2
 
 COPY --from=php-cli /usr/local/bin/phpdbg /usr/local/bin/
 ENV WEBROOT=docroot
@@ -21,7 +21,7 @@ RUN curl -L https://github.com/itchyny/gojq/releases/download/v${GOJQ_VERSION}/g
     chmod +x /tmp/gojq_v${GOJQ_VERSION}_linux_amd64/gojq && \
     mv /tmp/gojq_v${GOJQ_VERSION}_linux_amd64/gojq /usr/local/bin
 
-RUN wget -O - https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xzf - -C /usr/local/bin && \ 
+RUN wget -O - https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xzf - -C /usr/local/bin && \
     chmod +x /usr/local/bin/dockerize
 
 # Install redis-cli for debugging.

--- a/images/php/Dockerfile.fpm
+++ b/images/php/Dockerfile.fpm
@@ -2,7 +2,7 @@ ARG PHP_VERSION=8.3
 FROM ghcr.io/dpc-sdp/bay/php-fpm-exporter:6.x AS php-fpm-exporter
 FROM uselagoon/php-${PHP_VERSION}-fpm:latest
 
-ARG BAY_CLI_VERSION=v1.4.1
+ARG BAY_CLI_VERSION=v1.4.11
 
 RUN mkdir /bay
 COPY 01-bay.ini /usr/local/etc/php/conf.d/


### PR DESCRIPTION
Update all dependencies to their latest versions.

Additionally:

- Composer fixed a bug in 2.8.6 (`Fixed detection of containerd for containers to avoid warning about root usage (#12299)`) which has required the addition of `allow-plugins` commands.
- Updated deprecated `ENV <Var> <Value>` to `ENV <Var>=<Value>` in node image.