### PR TITLE
Added mysql image with percona xtrabackup available

### DIFF
--- a/gh-actions-bake.hcl
+++ b/gh-actions-bake.hcl
@@ -46,6 +46,13 @@ target "mariadb" {
 
   platforms     = ["linux/amd64", "linux/arm64"]
 }
+target "mysql" {
+  inherits = ["docker-metadata-action"]
+  context       = "${CONTEXT}/mysql"
+  dockerfile    = "Dockerfile"
+
+  platforms     = ["linux/amd64", "linux/arm64"]
+}
 target "nginx" {
   inherits = ["docker-metadata-action"]
   context       = "${CONTEXT}/nginx"

--- a/images/mysql/00-bay.cnf
+++ b/images/mysql/00-bay.cnf
@@ -1,0 +1,8 @@
+# The MySQL server
+[mysqld]
+innodb_flush_log_at_trx_commit = 1
+key_buffer_size = 8M
+max_connections = 5461
+max_heap_table_size = 16M
+table_open_cache = 20000
+tmp_table_size = 16M

--- a/images/mysql/Dockerfile
+++ b/images/mysql/Dockerfile
@@ -1,0 +1,15 @@
+FROM mysql:8.0
+
+USER root
+
+COPY 00-bay.cnf /etc/mysql/conf.d/
+
+RUN curl -fsSL -o /tmp/percona-release.rpm \
+        https://repo.percona.com/yum/percona-release-latest.noarch.rpm \
+    && rpm -ivh /tmp/percona-release.rpm \
+    && percona-release setup pxb-80 \
+    && microdnf install -y percona-xtrabackup-80 \
+    && microdnf clean all \
+    && rm -rf /tmp/percona-release.rpm /var/cache/dnf
+
+RUN xtrabackup --version

--- a/images/mysql/Dockerfile
+++ b/images/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.0
+FROM mysql:8.4
 
 USER root
 
@@ -7,8 +7,8 @@ COPY 00-bay.cnf /etc/mysql/conf.d/
 RUN curl -fsSL -o /tmp/percona-release.rpm \
         https://repo.percona.com/yum/percona-release-latest.noarch.rpm \
     && rpm -ivh /tmp/percona-release.rpm \
-    && percona-release setup pxb-80 \
-    && microdnf install -y percona-xtrabackup-80 \
+    && percona-release setup -y pdps84lts \
+    && microdnf install -y percona-xtrabackup-84 \
     && microdnf clean all \
     && rm -rf /tmp/percona-release.rpm /var/cache/dnf
 


### PR DESCRIPTION
## Motivation

For the AWS platform migration we need percona xtrabackup files available. This tool is incompatible with mariadb, which is what we're using db container images.

## Changes

Adds a new image `mysql` which uses mysql and has percona xtrabackup installed.

## Notes

Once this is built and hosted in ghcr, we can start building db container images using this in [the shared workflow](https://github.com/dpc-sdp/github-actions/blob/main/.github/workflows/run_db_trigger.yml).